### PR TITLE
add _pkgdown.yml

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@ paper.md
 paper.bib
 docs
 LICENSE
+^_pkgdown.yml$

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,69 @@
+reference:
+- title: "Distance Functions"
+  contents:
+    - distance
+    - dist_many_many
+    - dist_one_many
+    - dist_one_one
+    - getDistMethods
+    - dist.diversity
+    - estimate.probability
+- title: "Information Theory"
+  contents:
+    - H
+    - JE
+    - CE
+    - MI
+    - KL
+    - JSD
+    - gJSD
+- title: "Low Level Distance functions"
+  contents:
+    - additive_symm_chi_sq
+    - avg
+    - bhattacharyya
+    - canberra
+    - chebyshev
+    - clark_sq
+    - cosine_dist
+    - czekanowski
+    - dice_dist
+    - divergence_sq
+    - euclidean
+    - fidelity
+    - gower
+    - harmonic_mean_dist
+    - hellinger
+    - inner_product
+    - intersection_dist
+    - jaccard
+    - jeffreys
+    - jensen_difference
+    - jensen_shannon
+    - k_divergence
+    - kulczynski_d
+    - kullback_leibler_distance
+    - kumar_hassebrook
+    - kumar_johnson
+    - lorentzian
+    - manhattan
+    - matusita
+    - minkowski
+    - motyka
+    - neyman_chi_sq
+    - pearson_chi_sq
+    - prob_symm_chi_sq
+    - ruzicka
+    - soergel
+    - sorensen
+    - squared_chi_sq
+    - squared_chord
+    - squared_euclidean
+    - taneja
+    - tanimoto
+    - topsoe
+    - wave_hedges
+- title: "Other"
+  contents:
+    - binned.kernel.est
+    - lin.cor

--- a/docs/404.html
+++ b/docs/404.html
@@ -109,7 +109,7 @@ Content not found. Please use links in the navbar.
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -421,7 +421,7 @@ Public License instead of this License.
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/articles/Distances.html
+++ b/docs/articles/Distances.html
@@ -100,11 +100,19 @@
 <div class="section level2">
 <h2 id="how-to-use-distance">How to use <code>distance()</code><a class="anchor" aria-label="anchor" href="#how-to-use-distance"></a>
 </h2>
-<p>The <code><a href="../reference/distance.html">distance()</a></code> function implemented in <code>philentropy</code> is able to compute 46 different distances/similarities between probability density functions (see <code><a href="../reference/distance.html">?philentropy::distance</a></code> for details).</p>
+<p>The <code><a href="../reference/distance.html">distance()</a></code> function implemented in
+<code>philentropy</code> is able to compute 46 different
+distances/similarities between probability density functions (see
+<code><a href="../reference/distance.html">?philentropy::distance</a></code> for details).</p>
 <div class="section level3">
 <h3 id="simple-example">Simple Example<a class="anchor" aria-label="anchor" href="#simple-example"></a>
 </h3>
-<p>The <code><a href="../reference/distance.html">distance()</a></code> function is implemented using the same <em>logic</em> as R’s base function <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code> and takes a <code>matrix</code> or <code>data.frame</code> object as input. The corresponding <code>matrix</code> or <code>data.frame</code> should store probability density functions (as rows) for which distance computations should be performed.</p>
+<p>The <code><a href="../reference/distance.html">distance()</a></code> function is implemented using the same
+<em>logic</em> as R’s base function <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code> and takes
+a <code>matrix</code> or <code>data.frame</code> object as input. The
+corresponding <code>matrix</code> or <code>data.frame</code> should
+store probability density functions (as rows) for which distance
+computations should be performed.</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># define a probability density function P</span></span>
 <span><span class="va">P</span> <span class="op">&lt;-</span> <span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span></span>
@@ -113,7 +121,9 @@
 <span></span>
 <span><span class="co"># combine P and Q as matrix object</span></span>
 <span><span class="va">x</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind</a></span><span class="op">(</span><span class="va">P</span>,<span class="va">Q</span><span class="op">)</span></span></code></pre></div>
-<p>Please note that when defining a <code>matrix</code> from vectors, probability vectors should be combined as rows (<code><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind()</a></code>).</p>
+<p>Please note that when defining a <code>matrix</code> from vectors,
+probability vectors should be combined as rows
+(<code><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind()</a></code>).</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/drostlab/philentropy" class="external-link">philentropy</a></span><span class="op">)</span></span>
 <span></span>
@@ -121,14 +131,24 @@
 <span><span class="fu"><a href="../reference/distance.html">distance</a></span><span class="op">(</span><span class="va">x</span>, method <span class="op">=</span> <span class="st">"euclidean"</span><span class="op">)</span></span></code></pre></div>
 <pre><code><span><span class="va">euclidean</span> </span>
 <span><span class="fl">0.1280713</span></span></code></pre>
-<p>For this simple case you can compare the results with R’s base function to compute the euclidean distance <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code>.</p>
+<p>For this simple case you can compare the results with R’s base
+function to compute the euclidean distance
+<code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code>.</p>
 <div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># compute the Euclidean Distance using R's base function</span></span>
 <span><span class="fu">stats</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist</a></span><span class="op">(</span><span class="va">x</span>, method <span class="op">=</span> <span class="st">"euclidean"</span><span class="op">)</span></span></code></pre></div>
 <pre><code>          P
 Q 0.1280713</code></pre>
-<p>However, the R base function <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code> only computes the following distance measures: <code>"euclidean", "maximum", "manhattan", "canberra", "binary" or "minkowski"</code>, whereas <code><a href="../reference/distance.html">distance()</a></code> allows you to choose from 46 distance/similarity measures and when selecting the native distance functions underlying <code><a href="../reference/distance.html">distance()</a></code> users can speed up their computations 3-5x.</p>
-<p>To find out which <code>method</code>s are implemented in <code><a href="../reference/distance.html">distance()</a></code> you can consult the <code><a href="../reference/getDistMethods.html">getDistMethods()</a></code> function.</p>
+<p>However, the R base function <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code> only computes
+the following distance measures:
+<code>"euclidean", "maximum", "manhattan", "canberra", "binary" or "minkowski"</code>,
+whereas <code><a href="../reference/distance.html">distance()</a></code> allows you to choose from 46
+distance/similarity measures and when selecting the native distance
+functions underlying <code><a href="../reference/distance.html">distance()</a></code> users can speed up their
+computations 3-5x.</p>
+<p>To find out which <code>method</code>s are implemented in
+<code><a href="../reference/distance.html">distance()</a></code> you can consult the
+<code><a href="../reference/getDistMethods.html">getDistMethods()</a></code> function.</p>
 <div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># names of implemented distance/similarity functions</span></span>
 <span><span class="fu"><a href="../reference/getDistMethods.html">getDistMethods</a></span><span class="op">(</span><span class="op">)</span></span></code></pre></div>
@@ -144,13 +164,15 @@ Q 0.1280713</code></pre>
 [37] "additive_symm"     "kullback-leibler"  "jeffreys"          "k_divergence"     
 [41] "topsoe"            "jensen-shannon"    "jensen_difference" "taneja"           
 [45] "kumar-johnson"     "avg"</code></pre>
-<p>Now you can choose any distance/similarity <code>method</code> that serves you.</p>
+<p>Now you can choose any distance/similarity <code>method</code> that
+serves you.</p>
 <div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># compute the Jaccard Distance with default parameters</span></span>
 <span><span class="fu"><a href="../reference/distance.html">distance</a></span><span class="op">(</span><span class="va">x</span>, method <span class="op">=</span> <span class="st">"jaccard"</span><span class="op">)</span></span></code></pre></div>
 <pre><code><span> <span class="va">jaccard</span> </span>
 <span><span class="fl">0.133869</span></span></code></pre>
-<p>Analogously, in case a probability matrix is specified the following output is generated.</p>
+<p>Analogously, in case a probability matrix is specified the following
+output is generated.</p>
 <div class="sourceCode" id="cb10"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># combine three probabilty vectors to a probabilty matrix </span></span>
 <span><span class="va">ProbMatrix</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span>, <span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">)</span>,<span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">)</span><span class="op">)</span></span>
@@ -164,7 +186,10 @@ Q 0.1280713</code></pre>
 v1 0.0000000 0.12807130 0.13881717
 v2 0.1280713 0.00000000 0.01074588
 v3 0.1388172 0.01074588 0.00000000</code></pre>
-<p>Alternatively, users can specify the argument <code>use.row.names = TRUE</code> to maintain the rownames of the input matrix and pass them as rownames and colnames to the output distance matrix.</p>
+<p>Alternatively, users can specify the argument
+<code>use.row.names = TRUE</code> to maintain the rownames of the input
+matrix and pass them as rownames and colnames to the output distance
+matrix.</p>
 <div class="sourceCode" id="cb12"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># compute the euclidean distance between all </span></span>
 <span><span class="co"># pairwise comparisons of probability vectors</span></span>
@@ -174,7 +199,8 @@ v3 0.1388172 0.01074588 0.00000000</code></pre>
 Example1 0.0000000 0.12807130 0.13881717
 Example2 0.1280713 0.00000000 0.01074588
 Example3 0.1388172 0.01074588 0.00000000</code></pre>
-<p>This output differs from the output of <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code>.</p>
+<p>This output differs from the output of
+<code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code>.</p>
 <div class="sourceCode" id="cb14"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># compute the euclidean distance between all </span></span>
 <span><span class="co"># pairwise comparisons of probability vectors</span></span>
@@ -183,8 +209,13 @@ Example3 0.1388172 0.01074588 0.00000000</code></pre>
 <pre><code>           1          2
 2 0.12807130           
 3 0.13881717 0.01074588</code></pre>
-<p>Whereas <code><a href="../reference/distance.html">distance()</a></code> returns a symmetric distance matrix, <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code> returns only one part of the symmetric matrix.</p>
-<p>However, users can also specify the argument <code>as.dist.obj = TRUE</code> in <code><a href="../reference/distance.html">philentropy::distance()</a></code> to retrieve a <code><a href="../reference/distance.html">philentropy::distance()</a></code> output which is an object of type <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code>.</p>
+<p>Whereas <code><a href="../reference/distance.html">distance()</a></code> returns a symmetric distance matrix,
+<code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code> returns only one part of the symmetric
+matrix.</p>
+<p>However, users can also specify the argument
+<code>as.dist.obj = TRUE</code> in <code><a href="../reference/distance.html">philentropy::distance()</a></code>
+to retrieve a <code><a href="../reference/distance.html">philentropy::distance()</a></code> output which is an
+object of type <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code>.</p>
 <div class="sourceCode" id="cb16"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">ProbMatrix</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span>, <span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">)</span>,<span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">)</span><span class="op">)</span></span>
 <span><span class="fu"><a href="https://rdrr.io/r/base/colnames.html" class="external-link">rownames</a></span><span class="op">(</span><span class="va">ProbMatrix</span><span class="op">)</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/paste.html" class="external-link">paste0</a></span><span class="op">(</span><span class="st">"test"</span>, <span class="fl">1</span><span class="op">:</span><span class="fl">3</span><span class="op">)</span></span>
@@ -193,9 +224,15 @@ Example3 0.1388172 0.01074588 0.00000000</code></pre>
            test1      test2
 test2 0.12807130           
 test3 0.13881717 0.01074588</code></pre>
-<p>Now let’s compare the run times of base R and <code>philentropy</code>. For this purpose you need to install the <code>microbenchmark</code> package.</p>
+<p>Now let’s compare the run times of base R and
+<code>philentropy</code>. For this purpose you need to install the
+<code>microbenchmark</code> package.</p>
 <blockquote>
-<p>Note: Please make sure to insert vector objects (in our example P, Q) when directly running the low-level functions such as <code><a href="../reference/euclidean.html">euclidean()</a></code> etc. Otherwise, computational overheads are produced that <a href="https://github.com/drostlab/philentropy/issues/30" class="external-link">significantly slow down computations when using large vectors</a>.</p>
+<p>Note: Please make sure to insert vector objects (in our example P, Q)
+when directly running the low-level functions such as
+<code><a href="../reference/euclidean.html">euclidean()</a></code> etc. Otherwise, computational overheads are
+produced that <a href="https://github.com/drostlab/philentropy/issues/30" class="external-link">significantly
+slow down computations when using large vectors</a>.</p>
 </blockquote>
 <div class="sourceCode" id="cb18"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># install.packages("microbenchmark")</span></span>
@@ -211,8 +248,22 @@ test3 0.13881717 0.01074588</code></pre>
  distance(x, method = "euclidean", test.na = FALSE) 26.518 28.3495 29.73174 29.2210 30.1025 62.096   100
                       dist(x, method = "euclidean") 11.073 12.9375 14.65223 14.3340 15.1710 65.130   100
                    euclidean(P, Q, FALSE)  4.329  4.9605  5.72378  5.4815  6.1240 22.510   100</code></pre>
-<p>As you can see, although the <code><a href="../reference/distance.html">distance()</a></code> function is quite fast, the internal checks cause it to be 2x slower than the base <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function (for the <code>euclidean</code> example). Nevertheless, in case you need to implement a faster version of the corresponding distance measure you can type <code>philentropy::</code> and then <code>TAB</code> allowing you to select the base distance computation functions (written in C++), e.g. <code><a href="../reference/euclidean.html">philentropy::euclidean()</a></code> which is almost 3x faster than the base <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function.</p>
-<p>The advantage of <code><a href="../reference/distance.html">distance()</a></code> is that it implements 46 distance measures based on base C++ functions that can be accessed individually by typing <code>philentropy::</code> and then <code>TAB</code>. In future versions of <code>philentropy</code> I will optimize the <code><a href="../reference/distance.html">distance()</a></code> function so that internal checks for data type correctness and correct input data will take less termination time than the base <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function.</p>
+<p>As you can see, although the <code><a href="../reference/distance.html">distance()</a></code> function is
+quite fast, the internal checks cause it to be 2x slower than the base
+<code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function (for the <code>euclidean</code> example).
+Nevertheless, in case you need to implement a faster version of the
+corresponding distance measure you can type <code>philentropy::</code>
+and then <code>TAB</code> allowing you to select the base distance
+computation functions (written in C++),
+e.g. <code><a href="../reference/euclidean.html">philentropy::euclidean()</a></code> which is almost 3x faster
+than the base <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function.</p>
+<p>The advantage of <code><a href="../reference/distance.html">distance()</a></code> is that it implements 46
+distance measures based on base C++ functions that can be accessed
+individually by typing <code>philentropy::</code> and then
+<code>TAB</code>. In future versions of <code>philentropy</code> I will
+optimize the <code><a href="../reference/distance.html">distance()</a></code> function so that internal checks
+for data type correctness and correct input data will take less
+termination time than the base <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function.</p>
 <!--
 ## Detailed assessment of individual similarity and distance metrics
 
@@ -261,7 +312,7 @@ Euclid argued that that the __shortest__ distance between two points is always a
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/articles/Information_Theory.html
+++ b/docs/articles/Information_Theory.html
@@ -101,16 +101,27 @@
 <h2 id="information-theory-measures-in-philentropy">Information Theory measures in <code>philentropy</code><a class="anchor" aria-label="anchor" href="#information-theory-measures-in-philentropy"></a>
 </h2>
 <blockquote>
-<p>The laws of probability, so true in general, so fallacious in particular.</p>
+<p>The laws of probability, so true in general, so fallacious in
+particular.</p>
 <p>- Edward Gibbon</p>
 </blockquote>
-<p>Information theory and statistics were beautifully fused by <code>Solomon Kullback</code>. This fusion allowed to quantify correlations and similarities between random variables using a more sophisticated toolkit. Modern fields such as machine learning and statistical data science build upon this fusion and the most powerful statistical techniques used today are based on an information theoretic foundation.</p>
-<p>The <code>philentropy</code> package aims to follow this tradition and therefore, in addition to a comprehensive catalog of distance measures it also implements the most important information theory measures.</p>
+<p>Information theory and statistics were beautifully fused by
+<code>Solomon Kullback</code>. This fusion allowed to quantify
+correlations and similarities between random variables using a more
+sophisticated toolkit. Modern fields such as machine learning and
+statistical data science build upon this fusion and the most powerful
+statistical techniques used today are based on an information theoretic
+foundation.</p>
+<p>The <code>philentropy</code> package aims to follow this tradition
+and therefore, in addition to a comprehensive catalog of distance
+measures it also implements the most important information theory
+measures.</p>
 <div class="section level3">
 <h3 id="shannons-entropy-hx">Shannon’s Entropy H(X)<a class="anchor" aria-label="anchor" href="#shannons-entropy-hx"></a>
 </h3>
 <blockquote>
-<p><span class="math inline">\(H(X) = -\sum\limits_{i=1}^n P(x_i) * log_b(P(x_i))\)</span></p>
+<p><span class="math inline">\(H(X) = -\sum\limits_{i=1}^n P(x_i) *
+log_b(P(x_i))\)</span></p>
 </blockquote>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># define probabilities P(X)</span></span>
@@ -123,7 +134,9 @@
 <h3 id="shannons-joint-entropy-hxy">Shannon’s Joint-Entropy H(X,Y)<a class="anchor" aria-label="anchor" href="#shannons-joint-entropy-hxy"></a>
 </h3>
 <blockquote>
-<p><span class="math inline">\(H(X,Y) = -\sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) * log_b(P(x_i, y_j))\)</span></p>
+<p><span class="math inline">\(H(X,Y) =
+-\sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) * log_b(P(x_i,
+y_j))\)</span></p>
 </blockquote>
 <div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># define the joint distribution P(X,Y)</span></span>
@@ -136,7 +149,9 @@
 <h3 id="shannons-conditional-entropy-hx-y">Shannon’s Conditional-Entropy H(X | Y)<a class="anchor" aria-label="anchor" href="#shannons-conditional-entropy-hx-y"></a>
 </h3>
 <blockquote>
-<p><span class="math inline">\(H(Y|X) = \sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) * log_b( P(x_i) / P(x_i, y_j) )\)</span></p>
+<p><span class="math inline">\(H(Y|X) =
+\sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) * log_b( P(x_i) /
+P(x_i, y_j) )\)</span></p>
 </blockquote>
 <div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># define the distribution P(X)</span></span>
@@ -152,7 +167,9 @@
 <h3 id="mutual-information-ixy">Mutual Information I(X,Y)<a class="anchor" aria-label="anchor" href="#mutual-information-ixy"></a>
 </h3>
 <blockquote>
-<p><span class="math inline">\(MI(X,Y) = \sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) * log_b( P(x_i, y_j) / ( P(x_i) * P(y_j) )\)</span></p>
+<p><span class="math inline">\(MI(X,Y) =
+\sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) * log_b( P(x_i, y_j)
+/ ( P(x_i) * P(y_j) )\)</span></p>
 </blockquote>
 <div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># define the distribution P(X)</span></span>
@@ -170,11 +187,23 @@
 <h3 id="kullback-leibler-divergence">Kullback-Leibler Divergence<a class="anchor" aria-label="anchor" href="#kullback-leibler-divergence"></a>
 </h3>
 <blockquote>
-<p><span class="math inline">\(KL(P || Q) = \sum\limits_{i=1}^n P(p_i) * log_2(P(p_i) / P(q_i)) = H(P, Q) - H(P)\)</span></p>
+<p><span class="math inline">\(KL(P || Q) = \sum\limits_{i=1}^n P(p_i) *
+log_2(P(p_i) / P(q_i)) = H(P, Q) - H(P)\)</span></p>
 </blockquote>
-<p>where <code>H(P, Q)</code> denotes the joint entropy of the probability distributions <code>P</code> and <code>Q</code> and <code>H(P)</code> denotes the entropy of probability distribution <code>P</code>. In case <code>P = Q</code> then <code>KL(P, Q) = 0</code> and in case <code>P != Q</code> then <code>KL(P, Q) &gt; 0</code>.</p>
-<p>The KL divergence is a non-symmetric measure of the directed divergence between two probability distributions P and Q. It only fulfills the positivity property of a distance metric.</p>
-<p>Because of the relation <code>KL(P||Q) = H(P,Q) - H(P)</code>, the Kullback-Leibler divergence of two probability distributions <code>P</code> and <code>Q</code> is also named <code>Cross Entropy</code> of two probability distributions <code>P</code> and <code>Q</code>.</p>
+<p>where <code>H(P, Q)</code> denotes the joint entropy of the
+probability distributions <code>P</code> and <code>Q</code> and
+<code>H(P)</code> denotes the entropy of probability distribution
+<code>P</code>. In case <code>P = Q</code> then
+<code>KL(P, Q) = 0</code> and in case <code>P != Q</code> then
+<code>KL(P, Q) &gt; 0</code>.</p>
+<p>The KL divergence is a non-symmetric measure of the directed
+divergence between two probability distributions P and Q. It only
+fulfills the positivity property of a distance metric.</p>
+<p>Because of the relation <code>KL(P||Q) = H(P,Q) - H(P)</code>, the
+Kullback-Leibler divergence of two probability distributions
+<code>P</code> and <code>Q</code> is also named
+<code>Cross Entropy</code> of two probability distributions
+<code>P</code> and <code>Q</code>.</p>
 <div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># Kulback-Leibler Divergence between random variables P and Q</span></span>
 <span><span class="va">P</span> <span class="op">&lt;-</span> <span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span></span>
@@ -201,12 +230,21 @@ kullback-leibler
 <div class="section level3">
 <h3 id="jensen-shannon-divergence">Jensen-Shannon Divergence<a class="anchor" aria-label="anchor" href="#jensen-shannon-divergence"></a>
 </h3>
-<p>This function computes the <code>Jensen-Shannon Divergence</code> <code>JSD(P || Q)</code> between two probability distributions <code>P</code> and <code>Q</code> with equal weights <code>π_1</code> = <code>π_2</code> = 1/2.</p>
-<p>The Jensen-Shannon Divergence JSD(P || Q) between two probability distributions P and Q is defined as:</p>
+<p>This function computes the <code>Jensen-Shannon Divergence</code>
+<code>JSD(P || Q)</code> between two probability distributions
+<code>P</code> and <code>Q</code> with equal weights <code>π_1</code> =
+<code>π_2</code> = 1/2.</p>
+<p>The Jensen-Shannon Divergence JSD(P || Q) between two probability
+distributions P and Q is defined as:</p>
 <blockquote>
-<p><span class="math inline">\(JSD(P || Q) = 0.5 * (KL(P || R) + KL(Q || R))\)</span></p>
+<p><span class="math inline">\(JSD(P || Q) = 0.5 * (KL(P || R) + KL(Q ||
+R))\)</span></p>
 </blockquote>
-<p>where <code>R = 0.5 * (P + Q)</code> denotes the mid-point of the probability vectors <code>P</code> and <code>Q</code>, and <code>KL(P || R)</code>, <code>KL(Q || R)</code> denote the <code>Kullback-Leibler Divergence</code> of <code>P</code> and <code>R</code>, as well as <code>Q</code> and <code>R</code>.</p>
+<p>where <code>R = 0.5 * (P + Q)</code> denotes the mid-point of the
+probability vectors <code>P</code> and <code>Q</code>, and
+<code>KL(P || R)</code>, <code>KL(Q || R)</code> denote the
+<code>Kullback-Leibler Divergence</code> of <code>P</code> and
+<code>R</code>, as well as <code>Q</code> and <code>R</code>.</p>
 <div class="sourceCode" id="cb11"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># Jensen-Shannon Divergence between P and Q</span></span>
 <span><span class="va">P</span> <span class="op">&lt;-</span> <span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span></span>
@@ -266,11 +304,16 @@ v3 0.04358522 0.0002120578 0.0000000000</code></pre>
 <div class="section level3">
 <h3 id="generalized-jensen-shannon-divergence">Generalized Jensen-Shannon Divergence<a class="anchor" aria-label="anchor" href="#generalized-jensen-shannon-divergence"></a>
 </h3>
-<p>The generalized Jensen-Shannon Divergence <span class="math inline">\(gJSD_{\pi_1,...,\pi_n}(P_1, ..., P_n)\)</span> enables distance comparisons between multiple probability distributions <span class="math inline">\(P_1,...,P_n\)</span>:</p>
+<p>The generalized Jensen-Shannon Divergence <span class="math inline">\(gJSD_{\pi_1,...,\pi_n}(P_1, ..., P_n)\)</span>
+enables distance comparisons between multiple probability distributions
+<span class="math inline">\(P_1,...,P_n\)</span>:</p>
 <blockquote>
-<p><span class="math inline">\(gJSD_{\pi_1,...,\pi_n}(P_1, ..., P_n) = H(\sum_{i = 1}^n \pi_i*P_i) - \sum_{i = 1}^n \pi_i*H(P_i)\)</span></p>
+<p><span class="math inline">\(gJSD_{\pi_1,...,\pi_n}(P_1, ..., P_n) =
+H(\sum_{i = 1}^n \pi_i*P_i) - \sum_{i = 1}^n \pi_i*H(P_i)\)</span></p>
 </blockquote>
-<p>where <span class="math inline">\(\pi_1,...,\pi_n\)</span> denote the weights selected for the probability vectors <span class="math inline">\(P_1,...,P_n\)</span> and <span class="math inline">\(H(P_i)\)</span> denotes the Shannon Entropy of probability vector <span class="math inline">\(P_i\)</span>.</p>
+<p>where <span class="math inline">\(\pi_1,...,\pi_n\)</span> denote the
+weights selected for the probability vectors <span class="math inline">\(P_1,...,P_n\)</span> and <span class="math inline">\(H(P_i)\)</span> denotes the Shannon Entropy of
+probability vector <span class="math inline">\(P_i\)</span>.</p>
 <div class="sourceCode" id="cb17"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># generate example probability matrix for comparing three probability functions</span></span>
 <span><span class="va">Prob</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span>, <span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">)</span>, <span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">)</span><span class="op">)</span></span>
@@ -282,8 +325,12 @@ v3 0.04358522 0.0002120578 0.0000000000</code></pre>
 #&gt; Metric: 'gJSD'; unit = 'log2'; comparing: 3 vectors (v1, ... , v3).
 #&gt; Weights: v1 = 0.333333333333333, v2 = 0.333333333333333, v3 = 0.333333333333333
 [1] 0.03512892</code></pre>
-<p>As you can see, the <code>gJSD</code> function prints out the exact number of vectors that were used to compute the generalized JSD. By default, the weights are uniformly distributed (<code>weights = NULL</code>).</p>
-<p>Users can also specify non-uniformly distributed weights via specifying the <code>weights</code> argument:</p>
+<p>As you can see, the <code>gJSD</code> function prints out the exact
+number of vectors that were used to compute the generalized JSD. By
+default, the weights are uniformly distributed
+(<code>weights = NULL</code>).</p>
+<p>Users can also specify non-uniformly distributed weights via
+specifying the <code>weights</code> argument:</p>
 <div class="sourceCode" id="cb19"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># define probability matrix</span></span>
 <span><span class="va">Prob</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span>, <span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">)</span>, <span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">30</span><span class="op">:</span><span class="fl">39</span><span class="op">)</span><span class="op">)</span></span>
@@ -292,7 +339,9 @@ v3 0.04358522 0.0002120578 0.0000000000</code></pre>
 <pre><code>#&gt; Metric: 'gJSD'; unit = 'log2'; comparing: 3 vectors (v1, ... , v3).
 #&gt; Weights: v1 = 0.5, v2 = 0.25, v3 = 0.25
 [1] 0.04081969</code></pre>
-<p>Finally, users can use the argument <code>est.prob</code> to empirically estimate probability vectors when they wish to specify count vectors as input:</p>
+<p>Finally, users can use the argument <code>est.prob</code> to
+empirically estimate probability vectors when they wish to specify count
+vectors as input:</p>
 <div class="sourceCode" id="cb21"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">P.count</span> <span class="op">&lt;-</span> <span class="fl">1</span><span class="op">:</span><span class="fl">10</span></span>
 <span><span class="va">Q.count</span> <span class="op">&lt;-</span> <span class="fl">20</span><span class="op">:</span><span class="fl">29</span></span>
@@ -324,7 +373,7 @@ v3 0.04358522 0.0002120578 0.0000000000</code></pre>
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/articles/Introduction.html
+++ b/docs/articles/Introduction.html
@@ -100,29 +100,67 @@
 <div class="section level2">
 <h2 id="introduction-to-the-philentropy-package">Introduction to the <code>philentropy</code> Package<a class="anchor" aria-label="anchor" href="#introduction-to-the-philentropy-package"></a>
 </h2>
-<p>Comparison is a fundamental method of scientific research leading to more general insights about the processes that generate similarity or dissimilarity. In statistical terms comparisons between probability functions are performed to infer connections, correlations, or relationships between samples. The <code>philentropy</code> package implements optimized distance and similarity measures for comparing probability functions. These comparisons between probability functions have their foundations in a broad range of scientific disciplines from mathematics to ecology. The aim of this package is to provide a base framework for clustering, classification, statistical inference, goodness-of-fit, non-parametric statistics, information theory, and machine learning tasks that are based on comparing univariate or multivariate probability functions.</p>
-<p>Applying the method of comparison in statistics often means computing distances between probability functions. In this context <a href="https://users.uom.gr/~kouiruki/sung.pdf" class="external-link">Sung-Hyuk Cha (2007)</a> provides a clear definition of distance :</p>
+<p>Comparison is a fundamental method of scientific research leading to
+more general insights about the processes that generate similarity or
+dissimilarity. In statistical terms comparisons between probability
+functions are performed to infer connections, correlations, or
+relationships between samples. The <code>philentropy</code> package
+implements optimized distance and similarity measures for comparing
+probability functions. These comparisons between probability functions
+have their foundations in a broad range of scientific disciplines from
+mathematics to ecology. The aim of this package is to provide a base
+framework for clustering, classification, statistical inference,
+goodness-of-fit, non-parametric statistics, information theory, and
+machine learning tasks that are based on comparing univariate or
+multivariate probability functions.</p>
+<p>Applying the method of comparison in statistics often means computing
+distances between probability functions. In this context <a href="https://users.uom.gr/~kouiruki/sung.pdf" class="external-link">Sung-Hyuk Cha (2007)</a>
+provides a clear definition of distance :</p>
 <blockquote>
-<p>From the scientific and mathematical point of view, <em>distance</em> is defined as a quantitative degree of how far apart two objects are.</p>
+<p>From the scientific and mathematical point of view, <em>distance</em>
+is defined as a quantitative degree of how far apart two objects
+are.</p>
 </blockquote>
-<p>Hence, quantifying the distance of two objects requires the assumption about a particular space in which these objects live. For the euclidean distance, for example, this would mean comparison of objects (coordinates) in euclidean space (e.g. coordinate system) while other distance measures may require different spaces to allow sensitive and appropriate quantification of distances between objects (e.g. probability space). This aspect of quantifying the <code>degree of how far two objects are apart in a defined space</code> (adjusted definition) motivates the existence of diverse distance measures. <strong>As a result, the domain expert should appreciate the responsibility to decide in which space their model or experimental data is best represented and which distance metric then maximizes the usefulness of object comparison within this defined space</strong>.</p>
-<p>Cha’s comprehensive review of distance/similarity measures motivated me to implement all these measures to better understand their comparative nature. As Cha states:</p>
+<p>Hence, quantifying the distance of two objects requires the
+assumption about a particular space in which these objects live. For the
+euclidean distance, for example, this would mean comparison of objects
+(coordinates) in euclidean space (e.g. coordinate system) while other
+distance measures may require different spaces to allow sensitive and
+appropriate quantification of distances between objects
+(e.g. probability space). This aspect of quantifying the
+<code>degree of how far two objects are apart in a defined space</code>
+(adjusted definition) motivates the existence of diverse distance
+measures. <strong>As a result, the domain expert should appreciate the
+responsibility to decide in which space their model or experimental data
+is best represented and which distance metric then maximizes the
+usefulness of object comparison within this defined space</strong>.</p>
+<p>Cha’s comprehensive review of distance/similarity measures motivated
+me to implement all these measures to better understand their
+comparative nature. As Cha states:</p>
 <blockquote>
-<p>The choice of distance/similarity measures depends on the measurement type or representation of objects.</p>
+<p>The choice of distance/similarity measures depends on the measurement
+type or representation of objects.</p>
 </blockquote>
-<p>As a result, the <code>philentropy</code> package implements functions that are part of the following topics:</p>
+<p>As a result, the <code>philentropy</code> package implements
+functions that are part of the following topics:</p>
 <ul>
 <li>Distance Measure</li>
 <li>Information Theory</li>
 <li>Correlation Analyses</li>
 </ul>
-<p>Personally, I hope that some of these functions are helpful to the scientific community.</p>
+<p>Personally, I hope that some of these functions are helpful to the
+scientific community.</p>
 <div class="section level3">
 <h3 id="distance-measures">Distance Measures<a class="anchor" aria-label="anchor" href="#distance-measures"></a>
 </h3>
-<p>Here, the <a href="https://github.com/drostlab/philentropy/blob/master/vignettes/Distances.Rmd" class="external-link">Distance Measure Vignette</a> introduces how to work with the main function <code><a href="../reference/distance.html">distance()</a></code> that implements the 46 distance measures presented in Cha’s review.</p>
-<p>Furthermore, for each distance/similarity measure a short description on usage and performance is presented.</p>
-<p>The following probability distance/similarity measures will be described in detail:</p>
+<p>Here, the <a href="https://github.com/drostlab/philentropy/blob/master/vignettes/Distances.Rmd" class="external-link">Distance
+Measure Vignette</a> introduces how to work with the main function
+<code><a href="../reference/distance.html">distance()</a></code> that implements the 46 distance measures
+presented in Cha’s review.</p>
+<p>Furthermore, for each distance/similarity measure a short description
+on usage and performance is presented.</p>
+<p>The following probability distance/similarity measures will be
+described in detail:</p>
 </div>
 <div class="section level3">
 <h3 id="distance-and-similarity-measures">Distance and Similarity Measures<a class="anchor" aria-label="anchor" href="#distance-and-similarity-measures"></a>
@@ -132,13 +170,17 @@
 <span class="math inline">\(L_p\)</span> Minkowski Family<a class="anchor" aria-label="anchor" href="#l_p-minkowski-family"></a>
 </h4>
 <ul>
-<li>Euclidean : <span class="math inline">\(d = \sqrt{\sum_{i = 1}^N | P_i - Q_i |^2)}\)</span>
+<li>Euclidean : <span class="math inline">\(d = \sqrt{\sum_{i = 1}^N |
+P_i - Q_i |^2)}\)</span>
 </li>
-<li>Manhattan : <span class="math inline">\(d = \sum_{i = 1}^N | P_i - Q_i |\)</span>
+<li>Manhattan : <span class="math inline">\(d = \sum_{i = 1}^N | P_i -
+Q_i |\)</span>
 </li>
-<li>Minkowski : <span class="math inline">\(d = ( \sum_{i = 1}^N | P_i - Q_i |^p)^{1/p}\)</span>
+<li>Minkowski : <span class="math inline">\(d = ( \sum_{i = 1}^N | P_i -
+Q_i |^p)^{1/p}\)</span>
 </li>
-<li>Chebyshev : <span class="math inline">\(d = max | P_i - Q_i |\)</span>
+<li>Chebyshev : <span class="math inline">\(d = max | P_i - Q_i
+|\)</span>
 </li>
 </ul>
 </div>
@@ -147,17 +189,23 @@
 <span class="math inline">\(L_1\)</span> Family<a class="anchor" aria-label="anchor" href="#l_1-family"></a>
 </h4>
 <ul>
-<li>Sorensen : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i - Q_i |}{\sum_{i = 1}^N (P_i + Q_i)}\)</span>
+<li>Sorensen : <span class="math inline">\(d = \frac{\sum_{i = 1}^N |
+P_i - Q_i |}{\sum_{i = 1}^N (P_i + Q_i)}\)</span>
 </li>
-<li>Gower : <span class="math inline">\(d = \frac{1}{N} \dot \sum_{i = 1}^N | P_i - Q_i |\)</span>, where <span class="math inline">\(N\)</span> is the total number of elements <span class="math inline">\(i\)</span> in <span class="math inline">\(P_i\)</span> and <span class="math inline">\(Q_i\)</span>
+<li>Gower : <span class="math inline">\(d = \frac{1}{N} \dot \sum_{i =
+1}^N | P_i - Q_i |\)</span>, where <span class="math inline">\(N\)</span> is the total number of elements <span class="math inline">\(i\)</span> in <span class="math inline">\(P_i\)</span> and <span class="math inline">\(Q_i\)</span>
 </li>
-<li>Soergel : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i - Q_i |}{\sum_{i = 1}^N max(P_i , Q_i)}\)</span>
+<li>Soergel : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i
+- Q_i |}{\sum_{i = 1}^N max(P_i , Q_i)}\)</span>
 </li>
-<li>Kulczynski d : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i - Q_i |}{\sum_{i = 1}^N min(P_i , Q_i)}\)</span>
+<li>Kulczynski d : <span class="math inline">\(d = \frac{\sum_{i = 1}^N
+| P_i - Q_i |}{\sum_{i = 1}^N min(P_i , Q_i)}\)</span>
 </li>
-<li>Canberra : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i - Q_i |}{(P_i + Q_i)}\)</span>
+<li>Canberra : <span class="math inline">\(d = \frac{\sum_{i = 1}^N |
+P_i - Q_i |}{(P_i + Q_i)}\)</span>
 </li>
-<li>Lorentzian : <span class="math inline">\(d = \sum_{i = 1}^N ln(1 + | P_i - Q_i |)\)</span>
+<li>Lorentzian : <span class="math inline">\(d = \sum_{i = 1}^N ln(1 + |
+P_i - Q_i |)\)</span>
 </li>
 </ul>
 </div>
@@ -165,36 +213,55 @@
 <h4 id="intersection-family">Intersection Family<a class="anchor" aria-label="anchor" href="#intersection-family"></a>
 </h4>
 <ul>
-<li>Intersection : <span class="math inline">\(s = \sum_{i = 1}^N min(P_i , Q_i)\)</span>
+<li>Intersection : <span class="math inline">\(s = \sum_{i = 1}^N
+min(P_i , Q_i)\)</span>
 </li>
-<li>Non-Intersection : <span class="math inline">\(d = 1 - \sum_{i = 1}^N min(P_i , Q_i)\)</span>
+<li>Non-Intersection : <span class="math inline">\(d = 1 - \sum_{i =
+1}^N min(P_i , Q_i)\)</span>
 </li>
-<li>Wave Hedges : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i - Q_i |}{max(P_i , Q_i)}\)</span>
+<li>Wave Hedges : <span class="math inline">\(d = \frac{\sum_{i = 1}^N |
+P_i - Q_i |}{max(P_i , Q_i)}\)</span>
 </li>
-<li>Czekanowski : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i - Q_i |}{\sum_{i = 1}^N | P_i + Q_i |}\)</span>
+<li>Czekanowski : <span class="math inline">\(d = \frac{\sum_{i = 1}^N |
+P_i - Q_i |}{\sum_{i = 1}^N | P_i + Q_i |}\)</span>
 </li>
-<li>Motyka : <span class="math inline">\(d = \frac{\sum_{i = 1}^N min(P_i , Q_i)}{(P_i + Q_i)}\)</span>
+<li>Motyka : <span class="math inline">\(d = \frac{\sum_{i = 1}^N
+min(P_i , Q_i)}{(P_i + Q_i)}\)</span>
 </li>
-<li>Kulczynski s : <span class="math inline">\(d = \frac{\sum_{i = 1}^N min(P_i , Q_i)}{\sum_{i = 1}^N | P_i - Q_i |}\)</span>
+<li>Kulczynski s : <span class="math inline">\(d = \frac{\sum_{i = 1}^N
+min(P_i , Q_i)}{\sum_{i = 1}^N | P_i - Q_i |}\)</span>
 </li>
-<li>Tanimoto : <span class="math inline">\(d = \frac{\sum_{i = 1}^N (max(P_i , Q_i) - min(P_i , Q_i))}{\sum_{i = 1}^N max(P_i , Q_i)}\)</span> ; equivalent to Soergel</li>
-<li>Ruzicka : <span class="math inline">\(s = \frac{\sum_{i = 1}^N min(P_i , Q_i)}{\sum_{i = 1}^N max(P_i , Q_i)}\)</span> ; equivalent to 1 - Tanimoto = 1 - Soergel</li>
+<li>Tanimoto : <span class="math inline">\(d = \frac{\sum_{i = 1}^N
+(max(P_i , Q_i) - min(P_i , Q_i))}{\sum_{i = 1}^N max(P_i ,
+Q_i)}\)</span> ; equivalent to Soergel</li>
+<li>Ruzicka : <span class="math inline">\(s = \frac{\sum_{i = 1}^N
+min(P_i , Q_i)}{\sum_{i = 1}^N max(P_i , Q_i)}\)</span> ; equivalent to
+1 - Tanimoto = 1 - Soergel</li>
 </ul>
 </div>
 <div class="section level4">
 <h4 id="inner-product-family">Inner Product Family<a class="anchor" aria-label="anchor" href="#inner-product-family"></a>
 </h4>
 <ul>
-<li>Inner Product : <span class="math inline">\(s = \sum_{i = 1}^N P_i \dot Q_i\)</span>
+<li>Inner Product : <span class="math inline">\(s = \sum_{i = 1}^N P_i
+\dot Q_i\)</span>
 </li>
-<li>Harmonic mean : <span class="math inline">\(s = 2 \cdot \frac{ \sum_{i = 1}^N P_i \cdot Q_i}{P_i + Q_i}\)</span>
+<li>Harmonic mean : <span class="math inline">\(s = 2 \cdot \frac{
+\sum_{i = 1}^N P_i \cdot Q_i}{P_i + Q_i}\)</span>
 </li>
-<li>Cosine : <span class="math inline">\(s = \frac{\sum_{i = 1}^N P_i \cdot Q_i}{\sqrt{\sum_{i = 1}^N P_i^2} \cdot \sqrt{\sum_{i = 1}^N Q_i^2}}\)</span>
+<li>Cosine : <span class="math inline">\(s = \frac{\sum_{i = 1}^N P_i
+\cdot Q_i}{\sqrt{\sum_{i = 1}^N P_i^2} \cdot \sqrt{\sum_{i = 1}^N
+Q_i^2}}\)</span>
 </li>
-<li>Kumar-Hassebrook (PCE) : <span class="math inline">\(s = \frac{\sum_{i = 1}^N (P_i \cdot Q_i)}{(\sum_{i = 1}^N P_i^2 + \sum_{i = 1}^N Q_i^2 - \sum_{i = 1}^N (P_i \cdot Q_i))}\)</span>
+<li>Kumar-Hassebrook (PCE) : <span class="math inline">\(s =
+\frac{\sum_{i = 1}^N (P_i \cdot Q_i)}{(\sum_{i = 1}^N P_i^2 + \sum_{i =
+1}^N Q_i^2 - \sum_{i = 1}^N (P_i \cdot Q_i))}\)</span>
 </li>
-<li>Jaccard : <span class="math inline">\(d = 1 - \frac{\sum_{i = 1}^N P_i \cdot Q_i}{\sum_{i = 1}^N P_i^2 + \sum_{i = 1}^N Q_i^2 - \sum_{i = 1}^N P_i \cdot Q_i}\)</span> ; equivalent to 1 - Kumar-Hassebrook</li>
-<li>Dice : <span class="math inline">\(d = \frac{\sum_{i = 1}^N (P_i - Q_i)^2}{(\sum_{i = 1}^N P_i^2 + \sum_{i = 1}^N Q_i^2)}\)</span>
+<li>Jaccard : <span class="math inline">\(d = 1 - \frac{\sum_{i = 1}^N
+P_i \cdot Q_i}{\sum_{i = 1}^N P_i^2 + \sum_{i = 1}^N Q_i^2 - \sum_{i =
+1}^N P_i \cdot Q_i}\)</span> ; equivalent to 1 - Kumar-Hassebrook</li>
+<li>Dice : <span class="math inline">\(d = \frac{\sum_{i = 1}^N (P_i -
+Q_i)^2}{(\sum_{i = 1}^N P_i^2 + \sum_{i = 1}^N Q_i^2)}\)</span>
 </li>
 </ul>
 </div>
@@ -202,15 +269,20 @@
 <h4 id="squared-chord-family">Squared-chord Family<a class="anchor" aria-label="anchor" href="#squared-chord-family"></a>
 </h4>
 <ul>
-<li>Fidelity : <span class="math inline">\(s = \sum_{i = 1}^N \sqrt{P_i \cdot Q_i}\)</span>
+<li>Fidelity : <span class="math inline">\(s = \sum_{i = 1}^N \sqrt{P_i
+\cdot Q_i}\)</span>
 </li>
-<li>Bhattacharyya : <span class="math inline">\(d = - ln \sum_{i = 1}^N \sqrt{P_i \cdot Q_i}\)</span>
+<li>Bhattacharyya : <span class="math inline">\(d = - ln \sum_{i = 1}^N
+\sqrt{P_i \cdot Q_i}\)</span>
 </li>
-<li>Hellinger : <span class="math inline">\(d = 2 \cdot \sqrt{1 - \sum_{i = 1}^N \sqrt{P_i \cdot Q_i}}\)</span>
+<li>Hellinger : <span class="math inline">\(d = 2 \cdot \sqrt{1 -
+\sum_{i = 1}^N \sqrt{P_i \cdot Q_i}}\)</span>
 </li>
-<li>Matusita : <span class="math inline">\(d = \sqrt{2 - 2 \cdot \sum_{i = 1}^N \sqrt{P_i \cdot Q_i}}\)</span>
+<li>Matusita : <span class="math inline">\(d = \sqrt{2 - 2 \cdot \sum_{i
+= 1}^N \sqrt{P_i \cdot Q_i}}\)</span>
 </li>
-<li>Squared-chord : <span class="math inline">\(d = \sum_{i = 1}^N ( \sqrt{P_i} - \sqrt{Q_i} )^2\)</span>
+<li>Squared-chord : <span class="math inline">\(d = \sum_{i = 1}^N (
+\sqrt{P_i} - \sqrt{Q_i} )^2\)</span>
 </li>
 </ul>
 </div>
@@ -218,21 +290,30 @@
 <h4 id="squared-l_2-family-x2-squared-family">Squared <span class="math inline">\(L_2\)</span> family (<span class="math inline">\(X^2\)</span> squared family)<a class="anchor" aria-label="anchor" href="#squared-l_2-family-x2-squared-family"></a>
 </h4>
 <ul>
-<li>Squared Euclidean : <span class="math inline">\(d = \sum_{i = 1}^N ( P_i - Q_i )^2\)</span>
+<li>Squared Euclidean : <span class="math inline">\(d = \sum_{i = 1}^N (
+P_i - Q_i )^2\)</span>
 </li>
-<li>Pearson <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{Q_i} )\)</span>
+<li>Pearson <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{Q_i}
+)\)</span>
 </li>
-<li>Neyman <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{P_i} )\)</span>
+<li>Neyman <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{P_i}
+)\)</span>
 </li>
-<li>Squared <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{(P_i + Q_i)} )\)</span>
+<li>Squared <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{(P_i +
+Q_i)} )\)</span>
 </li>
-<li>Probabilistic Symmetric <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = 2 \cdot \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{(P_i + Q_i)} )\)</span>
+<li>Probabilistic Symmetric <span class="math inline">\(X^2\)</span> :
+<span class="math inline">\(d = 2 \cdot \sum_{i = 1}^N ( \frac{(P_i -
+Q_i )^2}{(P_i + Q_i)} )\)</span>
 </li>
-<li>Divergence : <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = 2 \cdot \sum_{i = 1}^N ( \frac{(P_i - Q_i )^2}{(P_i + Q_i)^2} )\)</span>
+<li>Divergence : <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = 2 \cdot \sum_{i = 1}^N ( \frac{(P_i - Q_i
+)^2}{(P_i + Q_i)^2} )\)</span>
 </li>
-<li>Clark : <span class="math inline">\(d = \sqrt{\sum_{i = 1}^N (\frac{| P_i - Q_i |}{(P_i + Q_i)^2}}\)</span>
+<li>Clark : <span class="math inline">\(d = \sqrt{\sum_{i = 1}^N
+(\frac{| P_i - Q_i |}{(P_i + Q_i)^2}}\)</span>
 </li>
-<li>Additive Symmetric <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{((P_i - Q_i)^2 \cdot (P_i + Q_i))}{(P_i \cdot Q_i)} )\)</span>
+<li>Additive Symmetric <span class="math inline">\(X^2\)</span> : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{((P_i - Q_i)^2 \cdot
+(P_i + Q_i))}{(P_i \cdot Q_i)} )\)</span>
 </li>
 </ul>
 </div>
@@ -240,17 +321,26 @@
 <h4 id="shannons-entropy-family">Shannon’s Entropy Family<a class="anchor" aria-label="anchor" href="#shannons-entropy-family"></a>
 </h4>
 <ul>
-<li>Kullback-Leibler : <span class="math inline">\(d = \sum_{i = 1}^N P_i \cdot log(\frac{P_i}{Q_i})\)</span>
+<li>Kullback-Leibler : <span class="math inline">\(d = \sum_{i = 1}^N
+P_i \cdot log(\frac{P_i}{Q_i})\)</span>
 </li>
-<li>Jeffreys : <span class="math inline">\(d = \sum_{i = 1}^N (P_i - Q_i) \cdot log(\frac{P_i}{Q_i})\)</span>
+<li>Jeffreys : <span class="math inline">\(d = \sum_{i = 1}^N (P_i -
+Q_i) \cdot log(\frac{P_i}{Q_i})\)</span>
 </li>
-<li>K divergence : <span class="math inline">\(d = \sum_{i = 1}^N P_i \cdot log(\frac{2 \cdot P_i}{P_i + Q_i})\)</span>
+<li>K divergence : <span class="math inline">\(d = \sum_{i = 1}^N P_i
+\cdot log(\frac{2 \cdot P_i}{P_i + Q_i})\)</span>
 </li>
-<li>Topsoe : <span class="math inline">\(d = \sum_{i = 1}^N ( P_i \cdot log(\frac{2 \cdot P_i}{P_i + Q_i}) ) + ( Q_i \cdot log(\frac{2 \cdot Q_i}{P_i + Q_i}) )\)</span>
+<li>Topsoe : <span class="math inline">\(d = \sum_{i = 1}^N ( P_i \cdot
+log(\frac{2 \cdot P_i}{P_i + Q_i}) ) + ( Q_i \cdot log(\frac{2 \cdot
+Q_i}{P_i + Q_i}) )\)</span>
 </li>
-<li>Jensen-Shannon : <span class="math inline">\(d = 0.5 \cdot ( \sum_{i = 1}^N P_i \cdot log(\frac{2 \cdot P_i}{P_i + Q_i}) + \sum_{i = 1}^N Q_i \cdot log(\frac{2 * Q_i}{P_i + Q_i}))\)</span>
+<li>Jensen-Shannon : <span class="math inline">\(d = 0.5 \cdot ( \sum_{i
+= 1}^N P_i \cdot log(\frac{2 \cdot P_i}{P_i + Q_i}) + \sum_{i = 1}^N Q_i
+\cdot log(\frac{2 * Q_i}{P_i + Q_i}))\)</span>
 </li>
-<li>Jensen difference : <span class="math inline">\(d = \sum_{i = 1}^N ( (\frac{P_i \cdot log(P_i) + Q_i \cdot log(Q_i)}{2}) - (\frac{P_i + Q_i}{2}) \cdot log(\frac{P_i + Q_i}{2}) )\)</span>
+<li>Jensen difference : <span class="math inline">\(d = \sum_{i = 1}^N (
+(\frac{P_i \cdot log(P_i) + Q_i \cdot log(Q_i)}{2}) - (\frac{P_i +
+Q_i}{2}) \cdot log(\frac{P_i + Q_i}{2}) )\)</span>
 </li>
 </ul>
 </div>
@@ -258,34 +348,57 @@
 <h4 id="combinations">Combinations<a class="anchor" aria-label="anchor" href="#combinations"></a>
 </h4>
 <ul>
-<li>Taneja : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{P_i + Q_i}{2}) \cdot log( \frac{P_i + Q_i}{( 2 \cdot \sqrt{P_i \cdot Q_i})} )\)</span>
+<li>Taneja : <span class="math inline">\(d = \sum_{i = 1}^N ( \frac{P_i
++ Q_i}{2}) \cdot log( \frac{P_i + Q_i}{( 2 \cdot \sqrt{P_i \cdot Q_i})}
+)\)</span>
 </li>
-<li>Kumar-Johnson : <span class="math inline">\(d = \sum_{i = 1}^N \frac{(P_i^2 - Q_i^2)^2}{2 \cdot (P_i \cdot Q_i)^{\frac{3}{2}}}\)</span>
+<li>Kumar-Johnson : <span class="math inline">\(d = \sum_{i = 1}^N
+\frac{(P_i^2 - Q_i^2)^2}{2 \cdot (P_i \cdot
+Q_i)^{\frac{3}{2}}}\)</span>
 </li>
-<li>Avg(<span class="math inline">\(L_1\)</span>, <span class="math inline">\(L_n\)</span>) : <span class="math inline">\(d = \frac{\sum_{i = 1}^N | P_i - Q_i| + max{ | P_i - Q_i |}}{2}\)</span>
+<li>Avg(<span class="math inline">\(L_1\)</span>, <span class="math inline">\(L_n\)</span>) : <span class="math inline">\(d =
+\frac{\sum_{i = 1}^N | P_i - Q_i| + max{ | P_i - Q_i
+|}}{2}\)</span>
 </li>
 </ul>
-<p><strong>Note</strong>: <span class="math inline">\(d\)</span> refers to distance measures, whereas <span class="math inline">\(s\)</span> denotes similarity measures.</p>
+<p><strong>Note</strong>: <span class="math inline">\(d\)</span> refers
+to distance measures, whereas <span class="math inline">\(s\)</span>
+denotes similarity measures.</p>
 </div>
 </div>
 <div class="section level3">
 <h3 id="information-theory">Information Theory<a class="anchor" aria-label="anchor" href="#information-theory"></a>
 </h3>
-<p>Modern methods for distribution comparisons have a strong <a href="http://compbio.biosci.uq.edu.au/mediawiki/upload/b/b3/Jaynes_PhysRev1957-1.pdf" class="external-link">information theoretic background</a>. This fact motivated me to name this package <code>philentropy</code> and as a result, several well established information theory measures are (and further will be) implemented in this package.</p>
+<p>Modern methods for distribution comparisons have a strong <a href="http://compbio.biosci.uq.edu.au/mediawiki/upload/b/b3/Jaynes_PhysRev1957-1.pdf" class="external-link">information
+theoretic background</a>. This fact motivated me to name this package
+<code>philentropy</code> and as a result, several well established
+information theory measures are (and further will be) implemented in
+this package.</p>
 <ul>
-<li>Shannon’s Entropy H(X) : <span class="math inline">\(H(X) = -\sum\limits_{i=1}^n P(x_i) \cdot log_b(P(x_i))\)</span>
+<li>Shannon’s Entropy H(X) : <span class="math inline">\(H(X) =
+-\sum\limits_{i=1}^n P(x_i) \cdot log_b(P(x_i))\)</span>
 </li>
-<li>Shannon’s Joint-Entropy H(X,Y) : <span class="math inline">\(H(X,Y) = -\sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) \cdot log_b(P(x_i, y_j))\)</span>
+<li>Shannon’s Joint-Entropy H(X,Y) : <span class="math inline">\(H(X,Y)
+= -\sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) \cdot log_b(P(x_i,
+y_j))\)</span>
 </li>
-<li>Shannon’s Conditional-Entropy H(X | Y) : <span class="math inline">\(H(Y|X) = \sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) \cdot log_b( \frac{P(x_i)}{P(x_i, y_j)})\)</span>
+<li>Shannon’s Conditional-Entropy H(X | Y) : <span class="math inline">\(H(Y|X) = \sum\limits_{i=1}^n\sum\limits_{j=1}^m
+P(x_i, y_j) \cdot log_b( \frac{P(x_i)}{P(x_i, y_j)})\)</span>
 </li>
-<li>Mutual Information I(X,Y) : <span class="math inline">\(MI(X,Y) = \sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) \cdot log_b( \frac{P(x_i, y_j)}{( P(x_i) * P(y_j) )})\)</span>
+<li>Mutual Information I(X,Y) : <span class="math inline">\(MI(X,Y) =
+\sum\limits_{i=1}^n\sum\limits_{j=1}^m P(x_i, y_j) \cdot log_b(
+\frac{P(x_i, y_j)}{( P(x_i) * P(y_j) )})\)</span>
 </li>
-<li>Kullback-Leibler Divergence : <span class="math inline">\(KL(P || Q) = \sum\limits_{i=1}^n P(p_i) \cdot log_2(\frac{P(p_i) }{P(q_i)}) = H(P, Q) - H(P)\)</span>
+<li>Kullback-Leibler Divergence : <span class="math inline">\(KL(P || Q)
+= \sum\limits_{i=1}^n P(p_i) \cdot log_2(\frac{P(p_i) }{P(q_i)}) = H(P,
+Q) - H(P)\)</span>
 </li>
-<li>Jensen-Shannon Divergence : <span class="math inline">\(JSD(P || Q) = 0.5 * (KL(P || R) + KL(Q || R))\)</span>
+<li>Jensen-Shannon Divergence : <span class="math inline">\(JSD(P || Q)
+= 0.5 * (KL(P || R) + KL(Q || R))\)</span>
 </li>
-<li>Generalized Jensen-Shannon Divergence : <span class="math inline">\(gJSD_{\pi_1,...,\pi_n}(P_1, ..., P_n) = H(\sum_{i = 1}^n \pi_i \cdot P_i) - \sum_{i = 1}^n \pi_i \cdot H(P_i)\)</span>
+<li>Generalized Jensen-Shannon Divergence : <span class="math inline">\(gJSD_{\pi_1,...,\pi_n}(P_1, ..., P_n) = H(\sum_{i
+= 1}^n \pi_i \cdot P_i) - \sum_{i = 1}^n \pi_i \cdot
+H(P_i)\)</span>
 </li>
 </ul>
 </div>
@@ -309,7 +422,7 @@
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/articles/Many_Distances.html
+++ b/docs/articles/Many_Distances.html
@@ -87,8 +87,10 @@
       </header><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
-      <h1 data-toc-skip>Comparing many probability density functions</h1>
-                        <h4 data-toc-skip class="author">Jakub Nowosad</h4>
+      <h1 data-toc-skip>Comparing many probability density
+functions</h1>
+                        <h4 data-toc-skip class="author">Jakub
+Nowosad</h4>
             
             <h4 data-toc-skip class="date">2021-08-20</h4>
       
@@ -99,29 +101,64 @@
 
     
     
-<p>The <strong>philentropy</strong> package has several mechanisms to calculate distances between probability density functions. The main one is to use the the <code><a href="../reference/distance.html">distance()</a></code> function, which enables to compute 46 different distances/similarities between probability density functions (see <code><a href="../reference/distance.html">?philentropy::distance</a></code> and <a href="Distances.html">a companion vignette</a> for details). Alternatively, it is possible to call each distance/dissimilarity function directly. For example, the <code><a href="../reference/euclidean.html">euclidean()</a></code> function will compute the euclidean distance, while <code>jaccard</code> - the Jaccard distance. The complete list of available distance measures are available with the <code><a href="../reference/getDistMethods.html">philentropy::getDistMethods()</a></code> function.</p>
-<p>Both of the above approaches have their pros and cons. The <code><a href="../reference/distance.html">distance()</a></code> function is more flexible as it allows users to use any distance measure and can return either a <code>matrix</code> or a <code>dist</code> object. It also has several defensive programming checks implemented, and thus, it is more appropriate for regular users. Single distance functions, such as <code><a href="../reference/euclidean.html">euclidean()</a></code> or <code><a href="../reference/jaccard.html">jaccard()</a></code>, can be, on the other hand, slightly faster as they directly call the underlining C++ code.</p>
-<p>Now, we introduce three new low-level functions that are intermediaries between <code><a href="../reference/distance.html">distance()</a></code> and single distance functions. They are fairly flexible, allowing to use of any implemented distance measure, but also usually faster than calling the <code><a href="../reference/distance.html">distance()</a></code> functions (especially, if it is needed to use many times). These functions are:</p>
+<p>The <strong>philentropy</strong> package has several mechanisms to
+calculate distances between probability density functions. The main one
+is to use the the <code><a href="../reference/distance.html">distance()</a></code> function, which enables to
+compute 46 different distances/similarities between probability density
+functions (see <code><a href="../reference/distance.html">?philentropy::distance</a></code> and <a href="Distances.html">a companion vignette</a> for details).
+Alternatively, it is possible to call each distance/dissimilarity
+function directly. For example, the <code><a href="../reference/euclidean.html">euclidean()</a></code> function
+will compute the euclidean distance, while <code>jaccard</code> - the
+Jaccard distance. The complete list of available distance measures are
+available with the <code><a href="../reference/getDistMethods.html">philentropy::getDistMethods()</a></code>
+function.</p>
+<p>Both of the above approaches have their pros and cons. The
+<code><a href="../reference/distance.html">distance()</a></code> function is more flexible as it allows users to
+use any distance measure and can return either a <code>matrix</code> or
+a <code>dist</code> object. It also has several defensive programming
+checks implemented, and thus, it is more appropriate for regular users.
+Single distance functions, such as <code><a href="../reference/euclidean.html">euclidean()</a></code> or
+<code><a href="../reference/jaccard.html">jaccard()</a></code>, can be, on the other hand, slightly faster as
+they directly call the underlining C++ code.</p>
+<p>Now, we introduce three new low-level functions that are
+intermediaries between <code><a href="../reference/distance.html">distance()</a></code> and single distance
+functions. They are fairly flexible, allowing to use of any implemented
+distance measure, but also usually faster than calling the
+<code><a href="../reference/distance.html">distance()</a></code> functions (especially, if it is needed to use
+many times). These functions are:</p>
 <ul>
 <li>
-<code><a href="../reference/dist_one_one.html">dist_one_one()</a></code> - expects two vectors (probability density functions), returns a single value</li>
+<code><a href="../reference/dist_one_one.html">dist_one_one()</a></code> - expects two vectors (probability
+density functions), returns a single value</li>
 <li>
-<code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> - expects one vector (a probability density function) and one matrix (a set of probability density functions), returns a vector of values</li>
+<code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> - expects one vector (a probability
+density function) and one matrix (a set of probability density
+functions), returns a vector of values</li>
 <li>
-<code><a href="../reference/dist_many_many.html">dist_many_many()</a></code> - expects two matrices (two sets of probability density functions), returns a matrix of values</li>
+<code><a href="../reference/dist_many_many.html">dist_many_many()</a></code> - expects two matrices (two sets of
+probability density functions), returns a matrix of values</li>
 </ul>
-<p>Let’s start testing them by attaching the <strong>philentropy</strong> package.</p>
+<p>Let’s start testing them by attaching the
+<strong>philentropy</strong> package.</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/drostlab/philentropy" class="external-link">philentropy</a></span><span class="op">)</span></span></code></pre></div>
 <div class="section level2">
 <h2 id="dist_one_one">
 <code>dist_one_one()</code><a class="anchor" aria-label="anchor" href="#dist_one_one"></a>
 </h2>
-<p><code><a href="../reference/dist_one_one.html">dist_one_one()</a></code> is a lower level equivalent to <code><a href="../reference/distance.html">distance()</a></code>. However, instead of accepting a numeric <code>data.frame</code> or <code>matrix</code>, it expects two vectors representing probability density functions. In this example, we create two vectors, <code>P</code> and <code>Q</code>.</p>
+<p><code><a href="../reference/dist_one_one.html">dist_one_one()</a></code> is a lower level equivalent to
+<code><a href="../reference/distance.html">distance()</a></code>. However, instead of accepting a numeric
+<code>data.frame</code> or <code>matrix</code>, it expects two vectors
+representing probability density functions. In this example, we create
+two vectors, <code>P</code> and <code>Q</code>.</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">P</span> <span class="op">&lt;-</span> <span class="fl">1</span><span class="op">:</span><span class="fl">10</span> <span class="op">/</span> <span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span></span>
 <span><span class="va">Q</span> <span class="op">&lt;-</span> <span class="fl">20</span><span class="op">:</span><span class="fl">29</span> <span class="op">/</span> <span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">)</span></span></code></pre></div>
-<p>To calculate the euclidean distance between them we can use several approaches - (a) build-in R <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function, (b) <code><a href="../reference/distance.html">philentropy::distance()</a></code>, (c) <code><a href="../reference/euclidean.html">philentropy::euclidean()</a></code>, or the new <code><a href="../reference/dist_one_one.html">dist_one_one()</a></code>.</p>
+<p>To calculate the euclidean distance between them we can use several
+approaches - (a) build-in R <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> function, (b)
+<code><a href="../reference/distance.html">philentropy::distance()</a></code>, (c)
+<code><a href="../reference/euclidean.html">philentropy::euclidean()</a></code>, or the new
+<code><a href="../reference/dist_one_one.html">dist_one_one()</a></code>.</p>
 <div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># install.packages("microbenchmark")</span></span>
 <span><span class="fu">microbenchmark</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/microbenchmark/man/microbenchmark.html" class="external-link">microbenchmark</a></span><span class="op">(</span></span>
@@ -130,32 +167,47 @@
 <span>  <span class="fu"><a href="../reference/euclidean.html">euclidean</a></span><span class="op">(</span><span class="va">P</span>, <span class="va">Q</span>, <span class="cn">FALSE</span><span class="op">)</span>,</span>
 <span>  <span class="fu"><a href="../reference/dist_one_one.html">dist_one_one</a></span><span class="op">(</span><span class="va">P</span>, <span class="va">Q</span>, method <span class="op">=</span> <span class="st">"euclidean"</span>, testNA <span class="op">=</span> <span class="cn">FALSE</span><span class="op">)</span></span>
 <span><span class="op">)</span></span></code></pre></div>
-<pre><code><span><span class="co">## Unit: microseconds</span></span>
+<pre><code><span><span class="co">## Warning in microbenchmark::microbenchmark(dist(rbind(P, Q), method =</span></span>
+<span><span class="co">## "euclidean"), : less accurate nanosecond times to avoid potential integer</span></span>
+<span><span class="co">## overflows</span></span></code></pre>
+<pre><code><span><span class="co">## Unit: nanoseconds</span></span>
 <span><span class="co">##                                                                                    expr</span></span>
 <span><span class="co">##                                                 dist(rbind(P, Q), method = "euclidean")</span></span>
 <span><span class="co">##  distance(rbind(P, Q), method = "euclidean", test.na = FALSE,      mute.message = TRUE)</span></span>
 <span><span class="co">##                                                                  euclidean(P, Q, FALSE)</span></span>
 <span><span class="co">##                                dist_one_one(P, Q, method = "euclidean", testNA = FALSE)</span></span>
-<span><span class="co">##     min     lq     mean  median     uq      max neval</span></span>
-<span><span class="co">##  21.212 22.365 26.91674 23.8455 24.457  261.898   100</span></span>
-<span><span class="co">##  32.974 33.886 61.63084 35.0545 36.832 2340.132   100</span></span>
-<span><span class="co">##   2.660  3.008  3.80653  3.2960  3.899   18.529   100</span></span>
-<span><span class="co">##   3.829  4.407  5.87694  5.0615  5.503   58.035   100</span></span></code></pre>
-<p>All of them return the same, single value. However, as you can see in the benchmark above, some are more flexible, and others are faster.</p>
+<span><span class="co">##   min      lq     mean  median      uq    max neval cld</span></span>
+<span><span class="co">##  6027  6396.0  8476.75  6724.0  7113.5 164943   100  ab</span></span>
+<span><span class="co">##  9512 10045.0 18886.24 10311.5 10844.5 845707   100  a </span></span>
+<span><span class="co">##   820   922.5  1442.79  1025.0  1107.0  32595   100   b</span></span>
+<span><span class="co">##  1230  1353.0  1758.90  1476.0  1599.0  27552   100   b</span></span></code></pre>
+<p>All of them return the same, single value. However, as you can see in
+the benchmark above, some are more flexible, and others are faster.</p>
 </div>
 <div class="section level2">
 <h2 id="dist_one_many">
 <code>dist_one_many()</code><a class="anchor" aria-label="anchor" href="#dist_one_many"></a>
 </h2>
-<p>The role of <code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> is to calculate distances between one probability density function (in a form of a <code>vector</code>) and a set of probability density functions (as rows in a <code>matrix</code>).</p>
+<p>The role of <code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> is to calculate distances
+between one probability density function (in a form of a
+<code>vector</code>) and a set of probability density functions (as rows
+in a <code>matrix</code>).</p>
 <p>Firstly, let’s create our example data.</p>
-<div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="fu"><a href="https://rdrr.io/r/base/Random.html" class="external-link">set.seed</a></span><span class="op">(</span><span class="fl">2020</span><span class="op">-</span><span class="fl">08</span><span class="op">-</span><span class="fl">20</span><span class="op">)</span></span>
 <span><span class="va">P</span> <span class="op">&lt;-</span> <span class="fl">1</span><span class="op">:</span><span class="fl">10</span> <span class="op">/</span> <span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span></span>
 <span><span class="va">M</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/t.html" class="external-link">t</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/lapply.html" class="external-link">replicate</a></span><span class="op">(</span><span class="fl">100</span>, <span class="fu"><a href="https://rdrr.io/r/base/sample.html" class="external-link">sample</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span>, size <span class="op">=</span> <span class="fl">10</span><span class="op">)</span> <span class="op">/</span> <span class="fl">55</span><span class="op">)</span><span class="op">)</span></span></code></pre></div>
-<p><code>P</code> is our input vector and <code>M</code> is our input matrix.</p>
-<p>Distances between the <code>P</code> vector and probability density functions in <code>M</code> can be calculated using several approaches. For example, we could write a <code>for</code> loop (adding a new code) or just use the existing <code><a href="../reference/distance.html">distance()</a></code> function and extract only one row (or column) from the results. The <code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> allows for this calculation directly as it goes through each row in <code>M</code> and calculates a given distance measure between <code>P</code> and values in this row.</p>
-<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
+<p><code>P</code> is our input vector and <code>M</code> is our input
+matrix.</p>
+<p>Distances between the <code>P</code> vector and probability density
+functions in <code>M</code> can be calculated using several approaches.
+For example, we could write a <code>for</code> loop (adding a new code)
+or just use the existing <code><a href="../reference/distance.html">distance()</a></code> function and extract
+only one row (or column) from the results. The
+<code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> allows for this calculation directly as it
+goes through each row in <code>M</code> and calculates a given distance
+measure between <code>P</code> and values in this row.</p>
+<div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># install.packages("microbenchmark")</span></span>
 <span><span class="fu">microbenchmark</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/microbenchmark/man/microbenchmark.html" class="external-link">microbenchmark</a></span><span class="op">(</span></span>
 <span>  <span class="fu"><a href="https://rdrr.io/r/base/matrix.html" class="external-link">as.matrix</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind</a></span><span class="op">(</span><span class="va">P</span>, <span class="va">M</span><span class="op">)</span>, method <span class="op">=</span> <span class="st">"euclidean"</span><span class="op">)</span><span class="op">)</span><span class="op">[</span><span class="fl">1</span>, <span class="op">]</span><span class="op">[</span><span class="op">-</span><span class="fl">1</span><span class="op">]</span>,</span>
@@ -167,24 +219,33 @@
 <span><span class="co">##                                      as.matrix(dist(rbind(P, M), method = "euclidean"))[1, ][-1]</span></span>
 <span><span class="co">##  distance(rbind(P, M), method = "euclidean", test.na = FALSE,      mute.message = TRUE)[1, ][-1]</span></span>
 <span><span class="co">##                                        dist_one_many(P, M, method = "euclidean", testNA = FALSE)</span></span>
-<span><span class="co">##        min        lq        mean    median        uq       max neval</span></span>
-<span><span class="co">##    333.213   438.964   601.08900   553.630   641.857  2787.836   100</span></span>
-<span><span class="co">##  25790.692 31707.734 38792.72013 36469.824 42673.513 83685.017   100</span></span>
-<span><span class="co">##     27.609    35.483    49.58433    44.281    50.076   178.512   100</span></span></code></pre>
-<p>The <code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> returns a vector of values. It is, in this case, much faster than <code><a href="../reference/distance.html">distance()</a></code>, and visibly faster than <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> while allowing for more possible distance measures to be used.</p>
+<span><span class="co">##       min        lq        mean     median        uq       max neval cld</span></span>
+<span><span class="co">##   141.491   166.337   179.89980   181.3225   192.413   299.300   100  a </span></span>
+<span><span class="co">##  9796.212 10308.589 11858.90929 10585.3185 13777.988 15164.670   100   b</span></span>
+<span><span class="co">##    10.045    10.701    14.06792    13.4685    16.031    56.867   100  a</span></span></code></pre>
+<p>The <code><a href="../reference/dist_one_many.html">dist_one_many()</a></code> returns a vector of values. It is,
+in this case, much faster than <code><a href="../reference/distance.html">distance()</a></code>, and visibly
+faster than <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">dist()</a></code> while allowing for more possible
+distance measures to be used.</p>
 </div>
 <div class="section level2">
 <h2 id="dist_many_many">
 <code>dist_many_many()</code><a class="anchor" aria-label="anchor" href="#dist_many_many"></a>
 </h2>
-<p><code><a href="../reference/dist_many_many.html">dist_many_many()</a></code> calculates distances between two sets of probability density functions (as rows in two <code>matrix</code> objects).</p>
+<p><code><a href="../reference/dist_many_many.html">dist_many_many()</a></code> calculates distances between two sets
+of probability density functions (as rows in two <code>matrix</code>
+objects).</p>
 <p>Let’s create two new <code>matrix</code> example data.</p>
-<div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="fu"><a href="https://rdrr.io/r/base/Random.html" class="external-link">set.seed</a></span><span class="op">(</span><span class="fl">2020</span><span class="op">-</span><span class="fl">08</span><span class="op">-</span><span class="fl">20</span><span class="op">)</span></span>
 <span><span class="va">M1</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/t.html" class="external-link">t</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/lapply.html" class="external-link">replicate</a></span><span class="op">(</span><span class="fl">10</span>, <span class="fu"><a href="https://rdrr.io/r/base/sample.html" class="external-link">sample</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span>, size <span class="op">=</span> <span class="fl">10</span><span class="op">)</span> <span class="op">/</span> <span class="fl">55</span><span class="op">)</span><span class="op">)</span></span>
 <span><span class="va">M2</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/t.html" class="external-link">t</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/lapply.html" class="external-link">replicate</a></span><span class="op">(</span><span class="fl">10</span>, <span class="fu"><a href="https://rdrr.io/r/base/sample.html" class="external-link">sample</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span>, size <span class="op">=</span> <span class="fl">10</span><span class="op">)</span> <span class="op">/</span> <span class="fl">55</span><span class="op">)</span><span class="op">)</span></span></code></pre></div>
-<p><code>M1</code> is our first input matrix and <code>M2</code> is our second input matrix. I am not aware of any function build-in R that allows calculating distances between rows of two matrices, and thus, to solve this problem, we can create our own - <code>many_dists()</code>…</p>
-<div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">
+<p><code>M1</code> is our first input matrix and <code>M2</code> is our
+second input matrix. I am not aware of any function build-in R that
+allows calculating distances between rows of two matrices, and thus, to
+solve this problem, we can create our own -
+<code>many_dists()</code>…</p>
+<div class="sourceCode" id="cb10"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">many_dists</span> <span class="op">=</span> <span class="kw">function</span><span class="op">(</span><span class="va">m1</span>, <span class="va">m2</span><span class="op">)</span><span class="op">{</span></span>
 <span>  <span class="va">r</span> <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/matrix.html" class="external-link">matrix</a></span><span class="op">(</span>nrow <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/nrow.html" class="external-link">nrow</a></span><span class="op">(</span><span class="va">m1</span><span class="op">)</span>, ncol <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/nrow.html" class="external-link">nrow</a></span><span class="op">(</span><span class="va">m2</span><span class="op">)</span><span class="op">)</span></span>
 <span>  <span class="kw">for</span> <span class="op">(</span><span class="va">i</span> <span class="kw">in</span> <span class="fu"><a href="https://rdrr.io/r/base/seq.html" class="external-link">seq_len</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/nrow.html" class="external-link">nrow</a></span><span class="op">(</span><span class="va">m1</span><span class="op">)</span><span class="op">)</span><span class="op">)</span><span class="op">{</span></span>
@@ -196,7 +257,7 @@
 <span>  <span class="va">r</span></span>
 <span><span class="op">}</span></span></code></pre></div>
 <p>… and compare it to <code><a href="../reference/dist_many_many.html">dist_many_many()</a></code>.</p>
-<div class="sourceCode" id="cb10"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb11"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># install.packages("microbenchmark")</span></span>
 <span><span class="fu">microbenchmark</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/microbenchmark/man/microbenchmark.html" class="external-link">microbenchmark</a></span><span class="op">(</span></span>
 <span>  <span class="fu">many_dists</span><span class="op">(</span><span class="va">M1</span>, <span class="va">M2</span><span class="op">)</span>,</span>
@@ -204,12 +265,15 @@
 <span><span class="op">)</span></span></code></pre></div>
 <pre><code><span><span class="co">## Unit: microseconds</span></span>
 <span><span class="co">##                                                          expr      min       lq</span></span>
-<span><span class="co">##                                            many_dists(M1, M2) 3030.675 3400.980</span></span>
-<span><span class="co">##  dist_many_many(M1, M2, method = "euclidean", testNA = FALSE)   44.261   52.123</span></span>
-<span><span class="co">##       mean    median        uq       max neval</span></span>
-<span><span class="co">##  4179.8278 3597.5785 3867.3770 15803.478   100</span></span>
-<span><span class="co">##    57.8797   56.3705   60.8115   126.199   100</span></span></code></pre>
-<p>Both <code>many_dists()</code>and <code><a href="../reference/dist_many_many.html">dist_many_many()</a></code> return a matrix. The above benchmark concludes that <code><a href="../reference/dist_many_many.html">dist_many_many()</a></code> is about 30 times faster than our custom <code>many_dists()</code> approach.</p>
+<span><span class="co">##                                            many_dists(M1, M2) 1038.940 1080.494</span></span>
+<span><span class="co">##  dist_many_many(M1, M2, method = "euclidean", testNA = FALSE)   15.088   16.277</span></span>
+<span><span class="co">##        mean    median       uq      max neval cld</span></span>
+<span><span class="co">##  1232.97537 1125.9420 1216.306 5800.516   100  a </span></span>
+<span><span class="co">##    18.62712   18.2655   20.213   44.936   100   b</span></span></code></pre>
+<p>Both <code>many_dists()</code>and <code><a href="../reference/dist_many_many.html">dist_many_many()</a></code>
+return a matrix. The above benchmark concludes that
+<code><a href="../reference/dist_many_many.html">dist_many_many()</a></code> is about 30 times faster than our custom
+<code>many_dists()</code> approach.</p>
 </div>
   </div>
 
@@ -230,7 +294,7 @@
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -87,7 +87,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -107,7 +107,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,11 +89,13 @@
 <div class="section level1">
 <div class="page-header"><h1 id="philentropy">philentropy<a class="anchor" aria-label="anchor" href="#philentropy"></a>
 </h1></div>
-
+<p><a href="https://travis-ci.org/HajkD/philentropy" class="external-link"><img src="https://travis-ci.org/HajkD/philentropy.svg?branch=master" alt="Travis-CI Build Status"></a> <a href="https://joss.theoj.org/papers/10.21105/joss.00765" class="external-link"><img src="http://joss.theoj.org/papers/cad5ffc246ce197b06ccad1af7d2932a/status.svg" alt="status"></a> <a href="https://github.com/r-hub/cranlogs.app" class="external-link"><img src="http://cranlogs.r-pkg.org/badges/philentropy" alt="rstudio mirror downloads"></a> <a href="https://github.com/r-hub/cranlogs.app" class="external-link"><img src="http://cranlogs.r-pkg.org/badges/grand-total/philentropy" alt="rstudio mirror downloads"></a></p>
 <div class="section level3">
 <h3 id="similarity-and-distance-quantification-between-probability-functions">Similarity and Distance Quantification between Probability Functions<a class="anchor" aria-label="anchor" href="#similarity-and-distance-quantification-between-probability-functions"></a>
 </h3>
-<blockquote><p>Describe and understand the world through data.</p></blockquote>
+<blockquote>
+<p>Describe and understand the world through data.</p>
+</blockquote>
 <p>Data collection and data comparison are the foundations of scientific research. <em>Mathematics</em> provides the abstract framework to describe patterns we observe in nature and <em>Statistics</em> provides the framework to quantify the uncertainty of these patterns. In statistics, natural patterns are described in form of probability distributions which either follow a fixed pattern (parametric distributions) or more dynamic patterns (non-parametric distributions).</p>
 <p>The <code>philentropy</code> package implements fundamental distance and similarity measures to quantify distances between probability density functions as well as traditional information theory measures. In this regard, it aims to provide a framework for comparing natural patterns in a statistical notation.</p>
 <p>This project is born out of my passion for statistics and I hope that it will be useful to the people who share it with me.</p>
@@ -109,7 +111,9 @@
 <h3 id="citation">Citation<a class="anchor" aria-label="anchor" href="#citation"></a>
 </h3>
 <p><strong>I am developing <code>philentropy</code> in my spare time and would be very grateful if you would consider citing the following paper in case <code>philentropy</code> was useful for your own research. I plan on maintaining and extending the <code>philentropy</code> functionality and usability in the next years and require citations to back up these efforts. Many thanks in advance :)</strong></p>
-<blockquote><p>HG Drost, (2018). <strong>Philentropy: Information Theory and Distance Quantification with R</strong>. <em>Journal of Open Source Software</em>, 3(26), 765. <a href="https://doi.org/10.21105/joss.00765" class="external-link uri">https://doi.org/10.21105/joss.00765</a></p></blockquote>
+<blockquote>
+<p>HG Drost, (2018). <strong>Philentropy: Information Theory and Distance Quantification with R</strong>. <em>Journal of Open Source Software</em>, 3(26), 765. <a href="https://doi.org/10.21105/joss.00765" class="external-link uri">https://doi.org/10.21105/joss.00765</a></p>
+</blockquote>
 </div>
 <div class="section level2">
 <h2 id="tutorials">Tutorials<a class="anchor" aria-label="anchor" href="#tutorials"></a>
@@ -215,7 +219,7 @@ jensen_difference            taneja
 <code class="sourceCode R"><span><span class="co"># install.packages("devtools")</span></span>
 <span><span class="co"># install the current version of philentropy on your system</span></span>
 <span><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://devtools.r-lib.org/" class="external-link">devtools</a></span><span class="op">)</span></span>
-<span><span class="fu"><a href="https://rdrr.io/pkg/remotes/man/install_github.html" class="external-link">install_github</a></span><span class="op">(</span><span class="st">"HajkD/philentropy"</span>, build_vignettes <span class="op">=</span> <span class="cn">TRUE</span>, dependencies <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span></code></pre></div>
+<span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html" class="external-link">install_github</a></span><span class="op">(</span><span class="st">"HajkD/philentropy"</span>, build_vignettes <span class="op">=</span> <span class="cn">TRUE</span>, dependencies <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span></code></pre></div>
 </div>
 <div class="section level3">
 <h3 id="news">NEWS<a class="anchor" aria-label="anchor" href="#news"></a>
@@ -263,7 +267,9 @@ jensen_difference            taneja
 <div class="section level3">
 <h3 id="studies-that-successfully-applied-the-philentropy-package">Studies that successfully applied the <code>philentropy</code> package<a class="anchor" aria-label="anchor" href="#studies-that-successfully-applied-the-philentropy-package"></a>
 </h3>
-<blockquote><ul>
+<blockquote>
+<ul>
+<li><p><strong>Annelid functional genomics reveal the origins of bilaterian life cycles</strong> FM Martín-Zamora, Y Liang, K Guynes et al.- <strong>Nature</strong>, 2023</p></li>
 <li><p><strong>An atlas of gene regulatory elements in adult mouse cerebrum</strong> YE Li, S Preissl, X Hou, Z Zhang, K Zhang et al.- <strong>Nature</strong>, 2021</p></li>
 <li><p><strong>Convergent somatic mutations in metabolism genes in chronic liver disease</strong> S Ng, F Rouhani, S Brunner, N Brzozowska et al. <strong>Nature</strong>, 2021</p></li>
 <li><p><strong>Antigen dominance hierarchies shape TCF1+ progenitor CD8 T cell phenotypes in tumors</strong> ML Burger, AM Cruz, GE Crossland et al. - <strong>Cell</strong>, 2021</p></li>
@@ -272,13 +278,17 @@ jensen_difference            taneja
 <li><p><strong>HERMES: a molecular-formula-oriented method to target the metabolome</strong> R Giné, J Capellades, JM Badia et al. - <strong>Nature Methods</strong>, 2021</p></li>
 <li><p><strong>The genetic architecture of temperature adaptation is shaped by population ancestry and not by selection regime</strong> KA Otte, V Nolte, F Mallard et al. - <strong>Genome Biology</strong>, 2021</p></li>
 <li><p><strong>The Tug1 lncRNA locus is essential for male fertility</strong> JP Lewandowski et al. - <strong>Genome Biology</strong>, 2020</p></li>
+<li><p><strong>Transcriptional vulnerabilities of striatal neurons in human and rodent models of Huntington’s disease</strong> A Matsushima, SS Pineda, JR Crittenden et al. - <strong>Nature Communications</strong>, 2023</p></li>
 <li><p><strong>Resolving the structure of phage–bacteria interactions in the context of natural diversity</strong> KM Kauffman, WK Chang, JM Brown et al. - <strong>Nature Communications</strong>, 2022</p></li>
 <li><p><strong>Gut microbiome-mediated metabolism effects on immunity in rural and urban African populations</strong> M Stražar, GS Temba, H Vlamakis et al. - <strong>Nature Communications</strong>, 2021</p></li>
 <li><p><strong>Aging, inflammation and DNA damage in the somatic testicular niche with idiopathic germ cell aplasia</strong> M Alfano, AS Tascini, F Pederzoli et al. - <strong>Nature communications</strong>, 2021</p></li>
 <li><p><strong>Single cell census of human kidney organoids shows reproducibility and diminished off-target cells after transplantation</strong> A Subramanian et al. - <strong>Nature Communications</strong>, 2019</p></li>
 <li><p><strong>Different languages, similar encoding efficiency: Comparable information rates across the human communicative niche</strong> C Coupé, YM Oh, D Dediu, F Pellegrino - <strong>Science Advances</strong>, 2019</p></li>
 <li><p><strong>Single-cell deletion analyses show control of pro–T cell developmental speed and pathways by Tcf7, Spi1, Gata3, Bcl11a, Erg, and Bcl11b</strong> W Zhou, F Gao, M Romero-Wolf, S Jo, EV Rothenberg - <strong>Science Immunology</strong>, 2022</p></li>
-<li><p><strong>Large-scale chromatin reorganization reactivates placenta-specific genes that drive cellular aging</strong> Z Liu, Q Ji, J Ren, P Yan, Z Wu, S Wang, L Sun, Z Wang et al - <strong>Developmental Cell</strong>, 2022</p></li>
+<li><p><strong>Large-scale iterated singing experiments reveal oral transmission mechanisms underlying music evolution</strong> M Anglada-Tort, PMC Harrison, H Lee, N Jacoby - <strong>Current Biology</strong>, 2023</p></li>
+<li><p><strong>TAS-Seq is a robust and sensitive amplification method for bead-based scRNA-seq</strong> S Shichino, S Ueha, S Hashimoto, T Ogawa et al. - <strong>Communications biology</strong>, 2022</p></li>
+<li><p>Mapping hormone-regulated cell-cell interaction networks in the human breast at single-cell resolution LM Murrow, RJ Weber, JA Caruso et al. - <strong>Cell Systems</strong>, 2022</p></li>
+<li><p><strong>Large-scale chromatin reorganization reactivates placenta-specific genes that drive cellular aging</strong> Z Liu, Q Ji, J Ren, P Yan, Z Wu, S Wang, L Sun, Z Wang et al. - <strong>Developmental Cell</strong>, 2022</p></li>
 <li><p><strong>Direct epitranscriptomic regulation of mammalian translation initiation through N4-acetylcytidine</strong> D Arango, D Sturgill, R Yang, T Kanai, P Bauer et al. - <strong>Molecular Cell</strong>, 2022</p></li>
 <li><p><strong>Loss of adaptive capacity in asthmatic patients revealed by biomarker fluctuation dynamics after rhinovirus challenge</strong> A Sinha et al. - <strong>eLife</strong>, 2019</p></li>
 <li><p><strong>Sex and hatching order modulate the association between MHC‐II diversity and fitness in early‐life stages of a wild seabird</strong> M Pineaux et al - <strong>Molecular Ecology</strong>, 2020</p></li>
@@ -286,6 +296,7 @@ jensen_difference            taneja
 <li><p><strong>Differential variation analysis enables detection of tumor heterogeneity using single-cell RNA-sequencing data</strong> EF Davis-Marcisak, TD Sherman et al. - <strong>Cancer research</strong>, 2019</p></li>
 <li><p><strong>Multi-Omics Investigation of Innate Navitoclax Resistance in Triple-Negative Breast Cancer Cells</strong> M Marczyk et al. - <strong>Cancers</strong>, 2020</p></li>
 <li><p><strong>Impact of Gut Microbiome on Hypertensive Patients with Low-Salt Intake: Shika Study Results</strong> S Nagase et al. - <strong>Frontiers in Medicine</strong>, 2020</p></li>
+<li><p>Children’s social networks in developmental psychology: A network approach to capture and describe early social environments N Burke, N Brezack, A Woodward - <strong>Frontiers in psychology</strong>, 2022</p></li>
 <li><p><strong>Combined TCR Repertoire Profiles and Blood Cell Phenotypes Predict Melanoma Patient Response to Personalized Neoantigen Therapy plus Anti-PD-1</strong> A Poran et al. - <strong>Cell Reports Medicine</strong>, 2020</p></li>
 <li><p><strong>Identification of a glioma functional network from gene fitness data using machine learning</strong> C Xiang, X Liu, D Zhou, Y Zhou, X Wang, F Chen - <strong>Journal of Cellular and Molecular Medicine</strong>, 2022</p></li>
 <li><p><strong>Prediction of New Risk Genes and Potential Drugs for Rheumatoid Arthritis from Multiomics Data</strong> AM Birga, L Ren, H Luo, Y Zhang, J Huang - <strong>Computational and Mathematical Methods in Medicine</strong>, 2022</p></li>
@@ -335,7 +346,8 @@ jensen_difference            taneja
 <li><p><strong>Community assembly during vegetation succession after metal mining is driven by multiple processes with temporal variation</strong> T Li, H Yang, X Yang, Z Guo, D Fu, C Liu, S Li et al. - <strong>Ecology and evolution</strong>, 2022</p></li>
 <li><p><strong>Integrative Organismal Biology</strong> J Katzke, P Puchenkov, H Stark, <strong>EP Economo</strong> - 2022</p></li>
 <li><p><strong>Optimizing use of US Ex-PVP inbred lines for enhancing agronomic performance of tropical Striga resistant maize inbred lines</strong> ARS Maazou, M Gedil, VO Adetimirin et al. - <strong>BMC Plant Biology</strong>, 2022</p></li>
-</ul></blockquote>
+</ul>
+</blockquote>
 </div>
 </div>
 <div class="section level2">
@@ -382,15 +394,7 @@ jensen_difference            taneja
 </ul>
 </div>
 
-<div class="dev-status">
-<h2 data-toc-skip>Dev status</h2>
-<ul class="list-unstyled">
-<li><a href="https://travis-ci.org/HajkD/philentropy" class="external-link"><img src="https://travis-ci.org/HajkD/philentropy.svg?branch=master" alt="Travis-CI Build Status"></a></li>
-<li><a href="https://joss.theoj.org/papers/10.21105/joss.00765" class="external-link"><img src="http://joss.theoj.org/papers/cad5ffc246ce197b06ccad1af7d2932a/status.svg" alt="status"></a></li>
-<li><a href="https://github.com/r-hub/cranlogs.app" class="external-link"><img src="http://cranlogs.r-pkg.org/badges/philentropy" alt="rstudio mirror downloads"></a></li>
-<li><a href="https://github.com/r-hub/cranlogs.app" class="external-link"><img src="http://cranlogs.r-pkg.org/badges/grand-total/philentropy" alt="rstudio mirror downloads"></a></li>
-</ul>
-</div>
+
 
   </div>
 </div>
@@ -403,7 +407,7 @@ jensen_difference            taneja
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -68,11 +68,15 @@
 
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.8.0.9000" id="version-0809000">Version 0.8.0.9000<a class="anchor" aria-label="anchor" href="#version-0809000"></a></h2>
-<div class="section level3"><h3 id="new-features-0-8-0-9000">New Features<a class="anchor" aria-label="anchor" href="#new-features-0-8-0-9000"></a></h3></div>
+<div class="section level3">
+<h3 id="new-features-0-8-0-9000">New Features<a class="anchor" aria-label="anchor" href="#new-features-0-8-0-9000"></a></h3>
+</div>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.7.0" id="version-070">Version 0.7.0<small>2022-11-05</small><a class="anchor" aria-label="anchor" href="#version-070"></a></h2>
-<div class="section level3"><h3 id="new-features-0-7-0">New Features<a class="anchor" aria-label="anchor" href="#new-features-0-7-0"></a></h3></div>
+<div class="section level3">
+<h3 id="new-features-0-7-0">New Features<a class="anchor" aria-label="anchor" href="#new-features-0-7-0"></a></h3>
+</div>
 <div class="section level3">
 <h3 id="updates-0-7-0">Updates<a class="anchor" aria-label="anchor" href="#updates-0-7-0"></a></h3>
 <ul><li>the <a href="https://drostlab.github.io/philentropy/articles/Distances.html" class="external-link">Distances</a> vignette now has a fixed documentation for the benchmarking of low-level distance functions. Many thanks to (<a href="https://github.com/Nowosad" class="external-link">@Nowosad</a>) <a href="https://github.com/drostlab/philentropy/issues/30" class="external-link">#30</a></li>
@@ -93,7 +97,7 @@
 <h3 id="updates-0-6-0">Updates<a class="anchor" aria-label="anchor" href="#updates-0-6-0"></a></h3>
 <ul><li>a new Vignette <a href="https://drostlab.github.io/philentropy/articles/Many_Distances.html" class="external-link">Comparing many probability density functions</a> (Many thanks to Jakub Nowosad)</li>
 <li>
-<code>dplyr</code> package dependency was removed and replaced by the <code>poorman</code> due to the heavy dependency burden of <code>dplyr</code>, since <code>philentropy</code> only used <code><a href="https://rdrr.io/pkg/dplyr/man/between.html" class="external-link">dplyr::between()</a></code> which is now <code><a href="https://nathaneastwood.github.io/poorman/reference/between.html" class="external-link">poorman::between()</a></code> (Many thanks to Patrice Kiener for this suggestion)</li>
+<code>dplyr</code> package dependency was removed and replaced by the <code>poorman</code> due to the heavy dependency burden of <code>dplyr</code>, since <code>philentropy</code> only used <code><a href="https://dplyr.tidyverse.org/reference/between.html" class="external-link">dplyr::between()</a></code> which is now <code><a href="https://nathaneastwood.github.io/poorman/reference/between.html" class="external-link">poorman::between()</a></code> (Many thanks to Patrice Kiener for this suggestion)</li>
 <li>
 <code>distance(..., as.dist.obj = TRUE)</code> now returns the same values as <code><a href="https://rdrr.io/r/stats/dist.html" class="external-link">stats::dist()</a></code> when working with 2 dimensional input matrices (2 vector inputs) (see <a href="https://github.com/drostlab/philentropy/issues/29" class="external-link">#29</a>) (Many thanks to Jakub Nowosad (<a href="https://github.com/Nowosad" class="external-link">@Nowosad</a>)) Example:</li>
 </ul><div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
@@ -115,12 +119,14 @@
 <h2 class="page-header" data-toc-text="0.5.0" id="version-050">Version 0.5.0<small>2021-05-12</small><a class="anchor" aria-label="anchor" href="#version-050"></a></h2>
 <div class="section level3">
 <h3 id="new-features-0-5-0">New Features<a class="anchor" aria-label="anchor" href="#new-features-0-5-0"></a></h3>
-<ul><li>the <code><a href="../reference/distance.html">distance()</a></code> function receives a new argument <code>mute.message</code> allowing users to mute message printing when running large-scale distance computations. Example:</li></ul><div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
+<ul><li>the <code><a href="../reference/distance.html">distance()</a></code> function receives a new argument <code>mute.message</code> allowing users to mute message printing when running large-scale distance computations. Example:</li>
+</ul><div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span></span>
 <span><span class="fu"><a href="../reference/distance.html">distance</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/cbind.html" class="external-link">rbind</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">1</span><span class="op">:</span><span class="fl">10</span><span class="op">)</span>, <span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">/</span><span class="fu"><a href="https://rdrr.io/r/base/sum.html" class="external-link">sum</a></span><span class="op">(</span><span class="fl">20</span><span class="op">:</span><span class="fl">29</span><span class="op">)</span><span class="op">)</span>, </span>
 <span>         method <span class="op">=</span> <span class="st">"euclidean"</span>, </span>
 <span>         mute.message <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span></code></pre></div>
-<ul><li>adding <code>markdown</code> dependency to <code>DESCRIPTION</code> (<a href="https://github.com/yihui/knitr/issues/1864" class="external-link">find details here</a>)</li></ul></div>
+<ul><li>adding <code>markdown</code> dependency to <code>DESCRIPTION</code> (<a href="https://github.com/yihui/knitr/issues/1864" class="external-link">find details here</a>)</li>
+</ul></div>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.4.0" id="version-040">Version 0.4.0<small>2020-01-09</small><a class="anchor" aria-label="anchor" href="#version-040"></a></h2>
@@ -157,13 +163,15 @@ Number of objects: 3 </code></pre>
 </div>
 <div class="section level3">
 <h3 id="bug-fixes-0-4-0">Bug fixes<a class="anchor" aria-label="anchor" href="#bug-fixes-0-4-0"></a></h3>
-<ul><li>fixing a bug in <code><a href="../reference/gJSD.html">gJSD()</a></code> which tested transposed matrix rows rather than transposed matrix columns for sum &gt; 1 (see issue <a href="https://github.com/drostlab/philentropy/issues/17" class="external-link">#17</a> ; many thanks to <a href="https://github.com/wkc1986" class="external-link">@wkc1986</a>)</li></ul></div>
+<ul><li>fixing a bug in <code><a href="../reference/gJSD.html">gJSD()</a></code> which tested transposed matrix rows rather than transposed matrix columns for sum &gt; 1 (see issue <a href="https://github.com/drostlab/philentropy/issues/17" class="external-link">#17</a> ; many thanks to <a href="https://github.com/wkc1986" class="external-link">@wkc1986</a>)</li>
+</ul></div>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.3.0" id="version-030">Version 0.3.0<small>2019-02-13</small><a class="anchor" aria-label="anchor" href="#version-030"></a></h2>
 <div class="section level3">
 <h3 id="new-functionality-0-3-0">New functionality<a class="anchor" aria-label="anchor" href="#new-functionality-0-3-0"></a></h3>
-<ul><li>exporting all Rcpp distance measure functions individually (see issue <a href="https://github.com/drostlab/philentropy/issues/9" class="external-link">#9</a>), this enables access to much faster computations (see micro benchmarks at <a href="https://hajkd.github.io/philentropy/articles/Distances.html" class="external-link uri">https://hajkd.github.io/philentropy/articles/Distances.html</a>)</li></ul></div>
+<ul><li>exporting all Rcpp distance measure functions individually (see issue <a href="https://github.com/drostlab/philentropy/issues/9" class="external-link">#9</a>), this enables access to much faster computations (see micro benchmarks at <a href="https://hajkd.github.io/philentropy/articles/Distances.html" class="external-link uri">https://hajkd.github.io/philentropy/articles/Distances.html</a>)</li>
+</ul></div>
 <div class="section level3">
 <h3 id="bug-fixes-0-3-0">Bug fixes<a class="anchor" aria-label="anchor" href="#bug-fixes-0-3-0"></a></h3>
 <ul><li><p>fixing bug which caused that KL distance returns NaN when P == 0 (see issue <a href="https://github.com/drostlab/philentropy/issues/10" class="external-link">#10</a>; Many thanks to <a href="https://github.com/KaiserDominici" class="external-link">@KaiserDominici</a>)</p></li>
@@ -194,13 +202,15 @@ Number of objects: 3 </code></pre>
 </ul></div>
 <div class="section level3">
 <h3 id="bug-fixes-0-1-0">Bug fixes<a class="anchor" aria-label="anchor" href="#bug-fixes-0-1-0"></a></h3>
-<ul><li>Fixing bug that caused that <code><a href="../reference/JSD.html">JSD()</a></code> gives NaN when any probability is 0 - see <a href="https://github.com/HajkD/philentropy/issues/1" class="external-link uri">https://github.com/HajkD/philentropy/issues/1</a> (Thanks to William Kurtis Chang)</li></ul></div>
+<ul><li>Fixing bug that caused that <code><a href="../reference/JSD.html">JSD()</a></code> gives NaN when any probability is 0 - see <a href="https://github.com/HajkD/philentropy/issues/1" class="external-link uri">https://github.com/HajkD/philentropy/issues/1</a> (Thanks to William Kurtis Chang)</li>
+</ul></div>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.0.2" id="version-002">Version 0.0.2<small>2017-05-04</small><a class="anchor" aria-label="anchor" href="#version-002"></a></h2>
 <div class="section level3">
 <h3 id="bug-fixes-0-0-2">Bug fixes<a class="anchor" aria-label="anchor" href="#bug-fixes-0-0-2"></a></h3>
-<ul><li>Fixing C++ memory leaks in <code><a href="../reference/dist.diversity.html">dist.diversity()</a></code> and <code><a href="../reference/distance.html">distance()</a></code> when check for <code>colSums(x) &gt; 1.001</code> was peformed (leak was found with <code>rhub::check_with_valgrind()</code>)</li></ul></div>
+<ul><li>Fixing C++ memory leaks in <code><a href="../reference/dist.diversity.html">dist.diversity()</a></code> and <code><a href="../reference/distance.html">distance()</a></code> when check for <code>colSums(x) &gt; 1.001</code> was peformed (leak was found with <code><a href="https://r-hub.github.io/rhub/reference/check_shortcuts.html" class="external-link">rhub::check_with_valgrind()</a></code>)</li>
+</ul></div>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.0.1" id="version-001">Version 0.0.1<small>2017-04-25</small><a class="anchor" aria-label="anchor" href="#version-001"></a></h2>
@@ -220,7 +230,7 @@ Number of objects: 3 </code></pre>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/paper.html
+++ b/docs/paper.html
@@ -67,6 +67,7 @@
 
 
 <div id="summary" class="section level1">
+
 <p>Comparison is a fundamental method of scientific research leading to insights about the processes that generate similarity or dissimilarity. In statistical terms comparisons between probability functions are performed to infer connections, correlations, or relationships between objects or samples [@Cha2007]. Most quantification methods rely on distance or similarity measures, but the right choice for each individual application is not always clear and sometimes poorly explored. The reason for this is partly that diverse measures are either implemented in different R packages with very different notations or are not implemented at all. Thus, a comprehensive framework implementing the most common similarity and distance measures using a uniform notation is still missing. The R [@R2018] package <code>Philentropy</code> aims to fill this gap by implementing forty-six fundamental distance and similarity measures [@Cha2007] for comparing probability functions. These comparisons between probability functions have their foundations in a broad range of scientific disciplines from mathematics to ecology. The aim of this package is to provide a comprehensive and computationally optimized base framework for clustering, classification, statistical inference, goodness-of-fit, non-parametric statistics, information theory, and machine learning tasks that are based on comparing univariate or multivariate probability functions. All functions are written in C++ and are integrated into the R package using the Rcpp Application Programming Interface (API) [@Eddelbuettel2013].</p>
 <p>Together, this framework allows building new similarity or distance based (statistical) models and algorithms in R which are computationally efficient and scalable. The comprehensive availability of diverse metrics and measures furthermore enables a systematic assessment of choosing the most optimal similarity or distance measure for individual applications in diverse scientific disciplines.</p>
 <p>The following probability distance/similarity and information theory measures are implemented in <code>Philentropy</code>.</p>
@@ -212,7 +213,9 @@
 <h1 id="acknowledgements">Acknowledgements<a class="anchor" aria-label="anchor" href="#acknowledgements"></a></h1>
 <p>I would like to thank Jerzy Paszkowski for providing me an inspiring scientific environment and for supporting my projects.</p>
 </div>
-<div class="section level1"><h1 id="references">References<a class="anchor" aria-label="anchor" href="#references"></a></h1></div>
+<div class="section level1">
+<h1 id="references">References<a class="anchor" aria-label="anchor" href="#references"></a></h1>
+</div>
 
 
   </div>
@@ -230,7 +233,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,10 +1,10 @@
-pandoc: 2.14.0.3
-pkgdown: 2.0.6
+pandoc: 3.1.1
+pkgdown: 2.0.7
 pkgdown_sha: ~
 articles:
   Distances: Distances.html
   Information_Theory: Information_Theory.html
   Introduction: Introduction.html
   Many_Distances: Many_Distances.html
-last_built: 2022-11-06T16:39Z
+last_built: 2023-10-18T00:56Z
 

--- a/docs/reference/CE.html
+++ b/docs/reference/CE.html
@@ -150,7 +150,7 @@ Communication". <em>Bell System Technical Journal</em> <b>27</b> (3): 379-423.</
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/H.html
+++ b/docs/reference/H.html
@@ -133,7 +133,7 @@ Communication". <em>Bell System Technical Journal</em> <b>27</b> (3): 379-423.</
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/JE.html
+++ b/docs/reference/JE.html
@@ -128,7 +128,7 @@ Communication". <em>Bell System Technical Journal</em> <b>27</b> (3): 379-423.</
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/JSD.html
+++ b/docs/reference/JSD.html
@@ -192,7 +192,7 @@ distributions". IEEE Trans. on Info. Thy. (49) 3: 1858-1860.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/KL.html
+++ b/docs/reference/KL.html
@@ -207,7 +207,7 @@ Theory. <em>John Wiley &amp; Sons</em>.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/MI.html
+++ b/docs/reference/MI.html
@@ -142,7 +142,7 @@ Communication". <em>Bell System Technical Journal</em> <b>27</b> (3): 379-423.</
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/additive_symm_chi_sq.html
+++ b/docs/reference/additive_symm_chi_sq.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/avg.html
+++ b/docs/reference/avg.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/bhattacharyya.html
+++ b/docs/reference/bhattacharyya.html
@@ -133,7 +133,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/binned.kernel.est.html
+++ b/docs/reference/binned.kernel.est.html
@@ -148,7 +148,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/canberra.html
+++ b/docs/reference/canberra.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/chebyshev.html
+++ b/docs/reference/chebyshev.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/clark_sq.html
+++ b/docs/reference/clark_sq.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/cosine_dist.html
+++ b/docs/reference/cosine_dist.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/czekanowski.html
+++ b/docs/reference/czekanowski.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/dice_dist.html
+++ b/docs/reference/dice_dist.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/dist.diversity.html
+++ b/docs/reference/dist.diversity.html
@@ -192,7 +192,7 @@ and returns a vector storing the corresponding distance measures. This vector is
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/dist_many_many.html
+++ b/docs/reference/dist_many_many.html
@@ -155,7 +155,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/dist_one_many.html
+++ b/docs/reference/dist_one_many.html
@@ -172,7 +172,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/dist_one_one.html
+++ b/docs/reference/dist_one_one.html
@@ -155,7 +155,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/distance.html
+++ b/docs/reference/distance.html
@@ -366,7 +366,7 @@ occur when dealing with 0 probabilities.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/divergence_sq.html
+++ b/docs/reference/divergence_sq.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/estimate.probability.html
+++ b/docs/reference/estimate.probability.html
@@ -133,7 +133,7 @@ probabilities of the corresponding counts.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/euclidean.html
+++ b/docs/reference/euclidean.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/fidelity.html
+++ b/docs/reference/fidelity.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/gJSD.html
+++ b/docs/reference/gJSD.html
@@ -174,7 +174,7 @@ denotes that <code>vec1</code> is weighted by <code>0.5</code>, <code>vec2</code
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/getDistMethods.html
+++ b/docs/reference/getDistMethods.html
@@ -119,7 +119,7 @@ function.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/gower.html
+++ b/docs/reference/gower.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/harmonic_mean_dist.html
+++ b/docs/reference/harmonic_mean_dist.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/hellinger.html
+++ b/docs/reference/hellinger.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -66,14 +66,42 @@
     </div>
 
     <table class="ref-index"><colgroup><col class="alias"><col class="title"></colgroup><tbody><tr><th colspan="2">
-          <h2 id="all-functions">All functions <a href="#all-functions" class="anchor" aria-hidden="true"></a></h2>
+          <h2 id="distance-functions">Distance Functions <a href="#distance-functions" class="anchor" aria-hidden="true"></a></h2>
           <p class="section-desc"></p>
         </th>
       </tr></tbody><tbody><tr><td>
-          <p><code><a href="CE.html">CE()</a></code> </p>
+          <p><code><a href="distance.html">distance()</a></code> </p>
         </td>
-        <td><p>Shannon's Conditional-Entropy \(H(X | Y)\)</p></td>
+        <td><p>Distances and Similarities between Probability Density Functions</p></td>
       </tr><tr><td>
+          <p><code><a href="dist_many_many.html">dist_many_many()</a></code> </p>
+        </td>
+        <td><p>Distances and Similarities between Many Probability Density Functions</p></td>
+      </tr><tr><td>
+          <p><code><a href="dist_one_many.html">dist_one_many()</a></code> </p>
+        </td>
+        <td><p>Distances and Similarities between One and Many Probability Density Functions</p></td>
+      </tr><tr><td>
+          <p><code><a href="dist_one_one.html">dist_one_one()</a></code> </p>
+        </td>
+        <td><p>Distances and Similarities between Two Probability Density Functions</p></td>
+      </tr><tr><td>
+          <p><code><a href="getDistMethods.html">getDistMethods()</a></code> </p>
+        </td>
+        <td><p>Get method names for <code>distance</code></p></td>
+      </tr><tr><td>
+          <p><code><a href="dist.diversity.html">dist.diversity()</a></code> </p>
+        </td>
+        <td><p>Distance Diversity between Probability Density Functions</p></td>
+      </tr><tr><td>
+          <p><code><a href="estimate.probability.html">estimate.probability()</a></code> </p>
+        </td>
+        <td><p>Estimate Probability Vectors From Count Vectors</p></td>
+      </tr></tbody><tbody><tr><th colspan="2">
+          <h2 id="information-theory">Information Theory <a href="#information-theory" class="anchor" aria-hidden="true"></a></h2>
+          <p class="section-desc"></p>
+        </th>
+      </tr></tbody><tbody><tr><td>
           <p><code><a href="H.html">H()</a></code> </p>
         </td>
         <td><p>Shannon's Entropy \(H(X)\)</p></td>
@@ -82,18 +110,30 @@
         </td>
         <td><p>Shannon's Joint-Entropy \(H(X,Y)\)</p></td>
       </tr><tr><td>
-          <p><code><a href="JSD.html">JSD()</a></code> </p>
+          <p><code><a href="CE.html">CE()</a></code> </p>
         </td>
-        <td><p>Jensen-Shannon Divergence</p></td>
-      </tr><tr><td>
-          <p><code><a href="KL.html">KL()</a></code> </p>
-        </td>
-        <td><p>Kullback-Leibler Divergence</p></td>
+        <td><p>Shannon's Conditional-Entropy \(H(X | Y)\)</p></td>
       </tr><tr><td>
           <p><code><a href="MI.html">MI()</a></code> </p>
         </td>
         <td><p>Shannon's Mutual Information \(I(X,Y)\)</p></td>
       </tr><tr><td>
+          <p><code><a href="KL.html">KL()</a></code> </p>
+        </td>
+        <td><p>Kullback-Leibler Divergence</p></td>
+      </tr><tr><td>
+          <p><code><a href="JSD.html">JSD()</a></code> </p>
+        </td>
+        <td><p>Jensen-Shannon Divergence</p></td>
+      </tr><tr><td>
+          <p><code><a href="gJSD.html">gJSD()</a></code> </p>
+        </td>
+        <td><p>Generalized Jensen-Shannon Divergence</p></td>
+      </tr></tbody><tbody><tr><th colspan="2">
+          <h2 id="low-level-distance-functions">Low Level Distance functions <a href="#low-level-distance-functions" class="anchor" aria-hidden="true"></a></h2>
+          <p class="section-desc"></p>
+        </th>
+      </tr></tbody><tbody><tr><td>
           <p><code><a href="additive_symm_chi_sq.html">additive_symm_chi_sq()</a></code> </p>
         </td>
         <td><p>Additive symmetric chi-squared distance (lowlevel function)</p></td>
@@ -105,10 +145,6 @@
           <p><code><a href="bhattacharyya.html">bhattacharyya()</a></code> </p>
         </td>
         <td><p>Bhattacharyya distance (lowlevel function)</p></td>
-      </tr><tr><td>
-          <p><code><a href="binned.kernel.est.html">binned.kernel.est()</a></code> </p>
-        </td>
-        <td><p>Kernel Density Estimation</p></td>
       </tr><tr><td>
           <p><code><a href="canberra.html">canberra()</a></code> </p>
         </td>
@@ -134,33 +170,9 @@
         </td>
         <td><p>Dice distance (lowlevel function)</p></td>
       </tr><tr><td>
-          <p><code><a href="dist.diversity.html">dist.diversity()</a></code> </p>
-        </td>
-        <td><p>Distance Diversity between Probability Density Functions</p></td>
-      </tr><tr><td>
-          <p><code><a href="dist_many_many.html">dist_many_many()</a></code> </p>
-        </td>
-        <td><p>Distances and Similarities between Many Probability Density Functions</p></td>
-      </tr><tr><td>
-          <p><code><a href="dist_one_many.html">dist_one_many()</a></code> </p>
-        </td>
-        <td><p>Distances and Similarities between One and Many Probability Density Functions</p></td>
-      </tr><tr><td>
-          <p><code><a href="dist_one_one.html">dist_one_one()</a></code> </p>
-        </td>
-        <td><p>Distances and Similarities between Two Probability Density Functions</p></td>
-      </tr><tr><td>
-          <p><code><a href="distance.html">distance()</a></code> </p>
-        </td>
-        <td><p>Distances and Similarities between Probability Density Functions</p></td>
-      </tr><tr><td>
           <p><code><a href="divergence_sq.html">divergence_sq()</a></code> </p>
         </td>
         <td><p>Divergence squared distance (lowlevel function)</p></td>
-      </tr><tr><td>
-          <p><code><a href="estimate.probability.html">estimate.probability()</a></code> </p>
-        </td>
-        <td><p>Estimate Probability Vectors From Count Vectors</p></td>
       </tr><tr><td>
           <p><code><a href="euclidean.html">euclidean()</a></code> </p>
         </td>
@@ -169,14 +181,6 @@
           <p><code><a href="fidelity.html">fidelity()</a></code> </p>
         </td>
         <td><p>Fidelity distance (lowlevel function)</p></td>
-      </tr><tr><td>
-          <p><code><a href="gJSD.html">gJSD()</a></code> </p>
-        </td>
-        <td><p>Generalized Jensen-Shannon Divergence</p></td>
-      </tr><tr><td>
-          <p><code><a href="getDistMethods.html">getDistMethods()</a></code> </p>
-        </td>
-        <td><p>Get method names for <code>distance</code></p></td>
       </tr><tr><td>
           <p><code><a href="gower.html">gower()</a></code> </p>
         </td>
@@ -233,10 +237,6 @@
           <p><code><a href="kumar_johnson.html">kumar_johnson()</a></code> </p>
         </td>
         <td><p>Kumar-Johnson distance (lowlevel function)</p></td>
-      </tr><tr><td>
-          <p><code><a href="lin.cor.html">lin.cor()</a></code> </p>
-        </td>
-        <td><p>Linear Correlation</p></td>
       </tr><tr><td>
           <p><code><a href="lorentzian.html">lorentzian()</a></code> </p>
         </td>
@@ -309,6 +309,18 @@
           <p><code><a href="wave_hedges.html">wave_hedges()</a></code> </p>
         </td>
         <td><p>Wave hedges distance (lowlevel function)</p></td>
+      </tr></tbody><tbody><tr><th colspan="2">
+          <h2 id="other">Other <a href="#other" class="anchor" aria-hidden="true"></a></h2>
+          <p class="section-desc"></p>
+        </th>
+      </tr></tbody><tbody><tr><td>
+          <p><code><a href="binned.kernel.est.html">binned.kernel.est()</a></code> </p>
+        </td>
+        <td><p>Kernel Density Estimation</p></td>
+      </tr><tr><td>
+          <p><code><a href="lin.cor.html">lin.cor()</a></code> </p>
+        </td>
+        <td><p>Linear Correlation</p></td>
       </tr></tbody></table></div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
@@ -322,7 +334,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/inner_product.html
+++ b/docs/reference/inner_product.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/intersection_dist.html
+++ b/docs/reference/intersection_dist.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/jaccard.html
+++ b/docs/reference/jaccard.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/jeffreys.html
+++ b/docs/reference/jeffreys.html
@@ -136,7 +136,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/jensen_difference.html
+++ b/docs/reference/jensen_difference.html
@@ -119,7 +119,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/jensen_shannon.html
+++ b/docs/reference/jensen_shannon.html
@@ -119,7 +119,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/k_divergence.html
+++ b/docs/reference/k_divergence.html
@@ -119,7 +119,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/kulczynski_d.html
+++ b/docs/reference/kulczynski_d.html
@@ -129,7 +129,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/kullback_leibler_distance.html
+++ b/docs/reference/kullback_leibler_distance.html
@@ -136,7 +136,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/kumar_hassebrook.html
+++ b/docs/reference/kumar_hassebrook.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/kumar_johnson.html
+++ b/docs/reference/kumar_johnson.html
@@ -129,7 +129,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/lin.cor.html
+++ b/docs/reference/lin.cor.html
@@ -123,7 +123,7 @@ The following methods to compute linear correlations are implemented in this fun
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/lorentzian.html
+++ b/docs/reference/lorentzian.html
@@ -119,7 +119,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/manhattan.html
+++ b/docs/reference/manhattan.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/matusita.html
+++ b/docs/reference/matusita.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/minkowski.html
+++ b/docs/reference/minkowski.html
@@ -116,7 +116,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/motyka.html
+++ b/docs/reference/motyka.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/neyman_chi_sq.html
+++ b/docs/reference/neyman_chi_sq.html
@@ -129,7 +129,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/pearson_chi_sq.html
+++ b/docs/reference/pearson_chi_sq.html
@@ -129,7 +129,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/prob_symm_chi_sq.html
+++ b/docs/reference/prob_symm_chi_sq.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/ruzicka.html
+++ b/docs/reference/ruzicka.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/soergel.html
+++ b/docs/reference/soergel.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/sorensen.html
+++ b/docs/reference/sorensen.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/squared_chi_sq.html
+++ b/docs/reference/squared_chi_sq.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/squared_chord.html
+++ b/docs/reference/squared_chord.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/squared_euclidean.html
+++ b/docs/reference/squared_euclidean.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/taneja.html
+++ b/docs/reference/taneja.html
@@ -136,7 +136,7 @@ technical issues of computing x / 0 or 0 / 0 cases.</p></dd>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/tanimoto.html
+++ b/docs/reference/tanimoto.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/topsoe.html
+++ b/docs/reference/topsoe.html
@@ -119,7 +119,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/wave_hedges.html
+++ b/docs/reference/wave_hedges.html
@@ -112,7 +112,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>


### PR DESCRIPTION
Hello all! 

Love the package, I noticed that the pkgdown site didn't have sections for the different functions, so everything was alphabetical. 

This PR adds a `_pkgdown.yml` file to specify sections to the reference page with all the functions.

All the big changes are happening in this commit [add _pkgdown.yml](https://github.com/drostlab/philentropy/commit/29005ba8224b6bb3b37337d6477d72593b5f8d39)